### PR TITLE
[Feat] #4: 초기 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ Thumbs.db
 
 ### Env or Local Configuration ###
 .env
-application-*.yml
 application-*.yaml
 application-*.properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+    // env
+    implementation 'io.github.cdimascio:dotenv-java:2.2.4'
+
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     //MySQL
     implementation 'mysql:mysql-connector-java:8.0.33'
 
+    // swagger
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 }
 
 dependencyManagement {

--- a/src/main/java/org/sopt36/ninedotserver/global/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.sopt36.ninedotserver.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/config/security/SecurityConfig.java
@@ -1,0 +1,22 @@
+package org.sopt36.ninedotserver.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package org.sopt36.ninedotserver.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi v1Api() {
+        return GroupedOpenApi.builder()
+            .group("v1")
+            .pathsToMatch("/api/v1/**")
+            .build();
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .servers(List.of(
+                new Server().url("https://api.ninedot.p-e.kr").description("Production"),
+                new Server().url("http://localhost:8080").description("Local")
+            ))
+            .components(new Components())
+            .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("NineDot Swagger")
+            .description("AT SOPT 36기 앱잼 | NineDot Swagger")
+            .version("1.0.0");
+    }
+}
+

--- a/src/main/java/org/sopt36/ninedotserver/global/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/dto/response/ApiResponse.java
@@ -1,0 +1,36 @@
+package org.sopt36.ninedotserver.global.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.sopt36.ninedotserver.global.exception.ErrorCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T, M>(int code, String message, T data, M meta) {
+
+    public ApiResponse(ErrorCode errorCode) {
+        this(errorCode.getStatus().value(), errorCode.getMessage(), null, null);
+    }
+
+    public static <T> ApiResponse<T, Void> ok(String message, T data) {
+        return new ApiResponse<>(200, message, data, null);
+    }
+
+    public static <T, M> ApiResponse<T, M> ok(String message, T data, M meta) {
+        return new ApiResponse<>(200, message, data, meta);
+    }
+
+    public static ApiResponse<Void, Void> ok(String message) {
+        return new ApiResponse<>(200, message, null, null);
+    }
+
+    public static ApiResponse<Void, Void> created(String message) {
+        return new ApiResponse<>(201, message, null, null);
+    }
+
+    public static ApiResponse<Void, ErrorMeta> error(ErrorCode errorCode, ErrorMeta meta) {
+        return new ApiResponse<>(errorCode.getStatus().value(), errorCode.getMessage(), null, meta);
+    }
+
+    public static ApiResponse<Void, ErrorMeta> error(int code, String message, ErrorMeta meta) {
+        return new ApiResponse<>(code, message, null, meta);
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/dto/response/ErrorMeta.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/dto/response/ErrorMeta.java
@@ -1,0 +1,8 @@
+package org.sopt36.ninedotserver.global.dto.response;
+
+public record ErrorMeta(
+    String path,
+    long timestamp
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/entity/BaseEntity.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package org.sopt36.ninedotserver.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/exception/BusinessException.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package org.sopt36.ninedotserver.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package org.sopt36.ninedotserver.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalErrorCode.java
@@ -1,0 +1,38 @@
+package org.sopt36.ninedotserver.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum GlobalErrorCode implements ErrorCode {
+
+    // 400 Bad Request
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 경로의 파라미터는 올바른 형식이 아닙니다."),
+    MISSING_HEADER(HttpStatus.BAD_REQUEST, "요청 헤더 '%s'가 누락되었습니다."),
+
+    // 404 Not Found
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    GlobalErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public String format(Object... args) {
+        return String.format(this.message, args);
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,107 @@
+package org.sopt36.ninedotserver.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.global.dto.response.ErrorMeta;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleBusinessException(
+        BusinessException ex,
+        HttpServletRequest request
+    ) {
+        log.error("BusinessException 발생: {}", ex.getMessage());
+
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(errorCode.getStatus())
+            .body(ApiResponse.error(errorCode, meta));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleMissingRequestException(
+        MissingRequestHeaderException ex,
+        HttpServletRequest request
+    ) {
+        log.error("요청 헤더 {}가 누락되었습니다.", ex.getHeaderName());
+
+        String message = GlobalErrorCode.MISSING_HEADER.format(ex.getHeaderName());
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message, meta));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleValidationException(
+        MethodArgumentNotValidException ex,
+        HttpServletRequest request
+    ) {
+        String message = ex.getBindingResult()
+            .getAllErrors()
+            .get(0)
+            .getDefaultMessage();
+        log.error("MethodArgumentNotValidException 발생: {}", message);
+
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message, meta));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleTypeMismatch(
+        MethodArgumentTypeMismatchException ex,
+        HttpServletRequest request
+    ) {
+        log.error("MethodArgumentTypeMismatchException 발생: {}", ex.getMessage());
+
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST.getStatus())
+            .body(ApiResponse.error(GlobalErrorCode.BAD_REQUEST, meta));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleNotFound(
+        NoHandlerFoundException ex,
+        HttpServletRequest request
+    ) {
+        log.error("NoHandlerFoundException 발생: {}", ex.getMessage());
+
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(GlobalErrorCode.RESOURCE_NOT_FOUND, meta));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void, ErrorMeta>> handleUnhandledException(
+        Exception ex,
+        HttpServletRequest request
+    ) {
+        log.error("서버 내부 오류 발생: {}", ex.getMessage());
+
+        ErrorMeta meta = createMeta(request);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error(GlobalErrorCode.INTERNAL_SERVER_ERROR, meta));
+    }
+
+    private ErrorMeta createMeta(HttpServletRequest request) {
+        return new ErrorMeta(request.getRequestURI(), System.currentTimeMillis());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  datasource:
+    url: ${LOCAL_SPRING_DATASOURCE_URL}
+    username: ${LOCAL_SPRING_DATASOURCE_USERNAME}
+    password: ${LOCAL_SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=NINEDOT-SERVER

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #4

### ⭐️ 구현 내용
- [x] application.yml, application-local.yml, application-prod.yml 구현
- [x] 기초 세팅
    - [x] BaseEntity
    - [x] ApiResponse
    - [x] ErrorHandling
    - [x] JpaAuditingConfig
    - [x] SwaggerConfig
    - [x] SecurityConfig

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
### 0️⃣ .env
요건 서버 노션 > 관리 정보 페이지에 BastionHost 사용해서 DataGrip 연결 방법, .env 두는 위치 등등 작성해 놓겠습니다! DataGrip 연결 방법이 쬐끔 어려울 수 있으니 꼼꼼하게 읽어주세요.

### 1️⃣ BaseEntity, JpaAuditingConfig
는 여러분들도 아실 것 같아서 설명 생략할게요!

### 2️⃣ ApiResponse에 meta 필드 추가

meta는 데이터에 대한 데이터로, 프론트가 필요한 데이터에 대한 설명을 해주는 데이터라고 보시면 될 것 같아요. 말이 조금 어려운데, 이번 페이지네이션 과제에서 현재 페이지가 몇 번째 페이지인지, 전체 페이지는 몇 개인지 등을 나타내주는 데이터들을 메타에 넣으면 된다고 생각하시면 됩니다! 

- 핸들러에서 단순히 오류 코드와 메시지만 보내주기보다는 어떤 경로에서 오류가 났는지, 언제 오류가 났는지 등을 함께 전달해주기 위해 ErrorMeta를 만들어서 함께 보내줍니다. 

### 3️⃣ 에러 처리
- 기존 핸들러에서 log를 사용하지 않으면 배포된 서버에서는 로그만 보고 어디서 터졌는지 알기 어려운 경우가 있었는데요. 이를 해결하기 위해 log를 추가하여 명시적으로 어느 예외가 터졌는지 알 수 있도록 합니다.
- 저 같은 경우는 기존에 global 패키지에 BusinessException을 두고, 각 도메인 별로 예외가 터졌을 때 모두 해당 exception을 던지도록 했는데요. 효율적인 유지보수, 높은 가독성, 도메인 모델의 명확한 경계를 위해 각 도메인에서는 BusinessException을 상속받는 도메인 예외 클래스를 만들어서 사용하면 좋을 것 같습니다.

### 4️⃣ Security Config
- 아직 보안 관련 설정이 조금 어색하실 텐데요! 제가 build.gradle에 미리 Spring Security 의존성을 추가해놓았어서 저번에 저희가 배포하면서 보았던 login 화면이 기본적으로 뜨게 됩니다. 즉, spring security가 포함된 프로젝트는 자동으로 모든 api 경로에 인증, 인가를 통해서만 접근할 수 있도록 설정됩니다. 근데 저희는 지금 당장은 그렇게 할 수가 없죠? 그래서 임시로 모든 경로에 대해서 인증, 인가를 하지 않도록 설정해 두었습니다. 당연히 추후 구글 로그인 구현 시 인증, 인가 관련 api만 허용하도록 바꾸어야 합니다.

### 5️⃣ Swagger Config
- 우리가 구현한 API를 자동으로 우리가 배포한 웹 사이트(로컬도 가능)에서 테스트할 수 있는 swagger를 붙였습니다.
- 로컬에서는 서버 실행시키고, http://localhost:8080/swagger-ui/index.html# 에 들어가면 테스트할 수 있어요.
- 자세한 내용은 [요 링크](https://velog.io/@stpn94/Swagger-%EB%9E%80-%EB%AC%B4%EC%97%87%EC%9D%B8%EA%B3%A0)를 참고해주세요!