### PR TITLE
[FEAT] #18: Mandalart(mandalart, CoreGoal, SubGoal, History) entity 생성

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -23,6 +23,8 @@ import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
 @Entity
 public class CoreGoal extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 30;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -57,7 +59,7 @@ public class CoreGoal extends BaseEntity {
         if (title == null || title.isBlank()) {
             throw new CoreGoalException(TITLE_NOT_BLANK);
         }
-        if (title.length() > 30) {
+        if (title.length() > MAX_TITLE_LENGTH) {
             throw new CoreGoalException(INVALID_TITLE_LENGTH);
         }
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -14,6 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
 
 @Getter
@@ -21,6 +23,7 @@ import org.sopt36.ninedotserver.global.entity.BaseEntity;
 @AllArgsConstructor
 @Builder(access = AccessLevel.PROTECTED)
 @Table(name = "core_goal")
+@DynamicInsert
 @Entity
 public class CoreGoal extends BaseEntity {
 
@@ -41,6 +44,7 @@ public class CoreGoal extends BaseEntity {
     private int position;
 
     @Column(name = "ai_generatable", nullable = false)
+    @ColumnDefault(value = "true")
     private boolean aiGeneratable;
 
     public static CoreGoal create(Mandalart mandalart,

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -47,13 +47,6 @@ public class CoreGoal extends BaseEntity {
     @Column(name = "ai_generatable", nullable = false)
     private boolean aiGeneratable;
 
-    private CoreGoal(Mandalart mandalart, String title, int position, boolean aiGeneratable) {
-        this.mandalart = mandalart;
-        this.title = title;
-        this.position = position;
-        this.aiGeneratable = aiGeneratable;
-    }
-
     @Builder
     public static CoreGoal create(Mandalart mandalart, String title, int position,
         boolean aiGeneratable) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -1,13 +1,22 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.INVALID_TITLE_LENGTH;
+import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.TITLE_NOT_BLANK;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
+import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,4 +26,39 @@ public class CoreGoal extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mandalart_id", nullable = false)
+    private Mandalart mandalart;
+
+    @Column(length = 30, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private int position;
+
+    @Column(nullable = false)
+    private boolean aiGeneratable;
+
+    private CoreGoal(Mandalart mandalart, String title, int position, boolean aiGeneratable) {
+        validateTitle(title);
+        this.mandalart = mandalart;
+        this.title = title;
+        this.position = position;
+        this.aiGeneratable = aiGeneratable;
+    }
+
+    public static CoreGoal create(Mandalart mandalart, String title, int position,
+        boolean aiGeneratable) {
+        return new CoreGoal(mandalart, title, position, aiGeneratable);
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new CoreGoalException(TITLE_NOT_BLANK);
+        }
+        if (title.length() > 30) {
+            throw new CoreGoalException(INVALID_TITLE_LENGTH);
+        }
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -40,7 +40,7 @@ public class CoreGoal extends BaseEntity {
     @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(name = "position", nullable = false, unique = true)
+    @Column(name = "position", nullable = false)
     private int position;
 
     @Column(name = "ai_generatable", nullable = false)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -11,7 +11,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,10 +22,11 @@ import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(access = AccessLevel.PROTECTED)
+@Table(name = "core_goal")
 @Entity
 public class CoreGoal extends BaseEntity {
-
-    private static final int MAX_TITLE_LENGTH = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,34 +36,31 @@ public class CoreGoal extends BaseEntity {
     @JoinColumn(name = "mandalart_id", nullable = false)
     private Mandalart mandalart;
 
-    @Column(length = 30, nullable = false)
+    @Column(name = "title", length = 30, nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(name = "position", nullable = false)
     private int position;
 
-    @Column(nullable = false)
+    @Column(name = "ai_generatable", nullable = false)
     private boolean aiGeneratable;
 
     private CoreGoal(Mandalart mandalart, String title, int position, boolean aiGeneratable) {
-        validateTitle(title);
         this.mandalart = mandalart;
         this.title = title;
         this.position = position;
         this.aiGeneratable = aiGeneratable;
     }
 
+    @Builder
     public static CoreGoal create(Mandalart mandalart, String title, int position,
         boolean aiGeneratable) {
-        return new CoreGoal(mandalart, title, position, aiGeneratable);
+        return CoreGoal.builder()
+            .mandalart(mandalart)
+            .title(title)
+            .position(position)
+            .aiGeneratable(aiGeneratable)
+            .build();
     }
 
-    private void validateTitle(String title) {
-        if (title == null || title.isBlank()) {
-            throw new CoreGoalException(TITLE_NOT_BLANK);
-        }
-        if (title.length() > MAX_TITLE_LENGTH) {
-            throw new CoreGoalException(INVALID_TITLE_LENGTH);
-        }
-    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -1,8 +1,5 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
-import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.INVALID_TITLE_LENGTH;
-import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.TITLE_NOT_BLANK;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
-import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -41,13 +37,12 @@ public class CoreGoal extends BaseEntity {
     @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(name = "position", nullable = false)
+    @Column(name = "position", nullable = false, unique = true)
     private int position;
 
     @Column(name = "ai_generatable", nullable = false)
     private boolean aiGeneratable;
 
-    @Builder
     public static CoreGoal create(Mandalart mandalart, String title, int position,
         boolean aiGeneratable) {
         return CoreGoal.builder()

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -43,8 +43,11 @@ public class CoreGoal extends BaseEntity {
     @Column(name = "ai_generatable", nullable = false)
     private boolean aiGeneratable;
 
-    public static CoreGoal create(Mandalart mandalart, String title, int position,
-        boolean aiGeneratable) {
+    public static CoreGoal create(Mandalart mandalart,
+        String title,
+        int position,
+        boolean aiGeneratable
+    ) {
         return CoreGoal.builder()
             .mandalart(mandalart)
             .title(title)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -28,6 +28,8 @@ import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
 @Entity
 public class CoreGoal extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 30;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,7 +38,7 @@ public class CoreGoal extends BaseEntity {
     @JoinColumn(name = "mandalart_id", nullable = false)
     private Mandalart mandalart;
 
-    @Column(name = "title", length = 30, nullable = false)
+    @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
     @Column(name = "position", nullable = false)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Cycle.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Cycle.java
@@ -1,0 +1,5 @@
+package org.sopt36.ninedotserver.mandalart.domain;
+
+public enum Cycle {
+    DAILY, WEEKLY, ONCE
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/History.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/History.java
@@ -1,9 +1,14 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,5 +22,20 @@ public class History extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subgoal_id", nullable = false)
+    private SubGoal subGoal;
+
+    @Column(nullable = false)
+    private LocalDate completedDate;
+
+    private History(SubGoal subGoal, LocalDate completedDate) {
+        this.subGoal = subGoal;
+        this.completedDate = completedDate;
+    }
+
+    public static History create(SubGoal subGoal, LocalDate completedDate) {
+        return new History(subGoal, completedDate);
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/History.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/History.java
@@ -8,14 +8,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(access = AccessLevel.PROTECTED)
+@Table(name = "history")
 @Entity
 public class History extends BaseEntity {
 
@@ -27,15 +33,14 @@ public class History extends BaseEntity {
     @JoinColumn(name = "subgoal_id", nullable = false)
     private SubGoal subGoal;
 
-    @Column(nullable = false)
+    @Column(name = "completed_date", nullable = false)
     private LocalDate completedDate;
 
-    private History(SubGoal subGoal, LocalDate completedDate) {
-        this.subGoal = subGoal;
-        this.completedDate = completedDate;
-    }
-
     public static History create(SubGoal subGoal, LocalDate completedDate) {
-        return new History(subGoal, completedDate);
+        return History.builder()
+            .subGoal(subGoal)
+            .completedDate(completedDate)
+            .build();
+
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -24,6 +24,8 @@ import org.sopt36.ninedotserver.user.domain.User;
 @Entity
 public class Mandalart extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 30;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -53,7 +55,7 @@ public class Mandalart extends BaseEntity {
         if (title == null || title.isBlank()) {
             throw new MandalartException(TITLE_NOT_BLANK);
         }
-        if (title.length() > 30) {
+        if (title.length() > MAX_TITLE_LENGTH) {
             throw new MandalartException(INVALID_TITLE_LENGTH);
         }
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -1,13 +1,23 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.INVALID_TITLE_LENGTH;
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.TITLE_NOT_BLANK;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
+import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
+import org.sopt36.ninedotserver.user.domain.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,4 +27,35 @@ public class Mandalart extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 30, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private boolean aiGeneratable;
+
+    private Mandalart(User user, String title, boolean aiGeneratable) {
+        validateTitle(title);
+        this.user = user;
+        this.title = title;
+        this.aiGeneratable = aiGeneratable;
+    }
+
+    public static Mandalart create(User user, String title, boolean aiGeneratable) {
+        return new Mandalart(user, title, aiGeneratable);
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new MandalartException(TITLE_NOT_BLANK);
+        }
+        if (title.length() > 30) {
+            throw new MandalartException(INVALID_TITLE_LENGTH);
+        }
+    }
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
 import org.sopt36.ninedotserver.user.domain.User;
 
@@ -23,6 +24,7 @@ import org.sopt36.ninedotserver.user.domain.User;
 @AllArgsConstructor
 @Builder(access = AccessLevel.PROTECTED)
 @Table(name = "mandalart")
+@DynamicInsert
 @Entity
 public class Mandalart extends BaseEntity {
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -25,6 +25,8 @@ import org.sopt36.ninedotserver.user.domain.User;
 @Entity
 public class Mandalart extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 30;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,7 +35,7 @@ public class Mandalart extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "title", length = 30, nullable = false)
+    @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
     @Column(name = "ai_generatable", nullable = false)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -1,8 +1,5 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
-import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.INVALID_TITLE_LENGTH;
-import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.TITLE_NOT_BLANK;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,20 +8,22 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
-import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.user.domain.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(access = AccessLevel.PROTECTED)
+@Table(name = "mandarlart")
 @Entity
 public class Mandalart extends BaseEntity {
-
-    private static final int MAX_TITLE_LENGTH = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,30 +33,17 @@ public class Mandalart extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(length = 30, nullable = false)
+    @Column(name = "title", length = 30, nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(name = "ai_generatable", nullable = false)
     private boolean aiGeneratable;
 
-    private Mandalart(User user, String title, boolean aiGeneratable) {
-        validateTitle(title);
-        this.user = user;
-        this.title = title;
-        this.aiGeneratable = aiGeneratable;
-    }
-
     public static Mandalart create(User user, String title, boolean aiGeneratable) {
-        return new Mandalart(user, title, aiGeneratable);
+        return Mandalart.builder()
+            .user(user)
+            .title(title)
+            .aiGeneratable(aiGeneratable)
+            .build();
     }
-
-    private void validateTitle(String title) {
-        if (title == null || title.isBlank()) {
-            throw new MandalartException(TITLE_NOT_BLANK);
-        }
-        if (title.length() > MAX_TITLE_LENGTH) {
-            throw new MandalartException(INVALID_TITLE_LENGTH);
-        }
-    }
-
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
 import org.sopt36.ninedotserver.user.domain.User;
 
@@ -21,7 +22,7 @@ import org.sopt36.ninedotserver.user.domain.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(access = AccessLevel.PROTECTED)
-@Table(name = "mandarlart")
+@Table(name = "mandalart")
 @Entity
 public class Mandalart extends BaseEntity {
 
@@ -39,6 +40,7 @@ public class Mandalart extends BaseEntity {
     private String title;
 
     @Column(name = "ai_generatable", nullable = false)
+    @ColumnDefault(value = "true")
     private boolean aiGeneratable;
 
     public static Mandalart create(User user, String title, boolean aiGeneratable) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -37,7 +37,7 @@ public class SubGoal extends BaseEntity {
     @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(name = "position", nullable = false, unique = true)
+    @Column(name = "position", nullable = false)
     private int position;
 
     public static SubGoal create(CoreGoal coreGoal, String title, int position) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -1,20 +1,61 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.INVALID_TITLE_LENGTH;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.TITLE_NOT_BLANK;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
+import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class SubGoal extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 30;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "core_id", nullable = false)
+    private CoreGoal coreGoal;
+
+    @Column(length = 30, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private int position;
+
+    private SubGoal(CoreGoal coreGoal, String title, int position) {
+        validateTitle(title);
+        this.coreGoal = coreGoal;
+        this.title = title;
+        this.position = position;
+    }
+
+    public static SubGoal create(CoreGoal coreGoal, String title, int position) {
+        return new SubGoal(coreGoal, title, position);
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new SubGoalException(TITLE_NOT_BLANK);
+        }
+        if (title.length() > MAX_TITLE_LENGTH) {
+            throw new SubGoalException(INVALID_TITLE_LENGTH);
+        }
+    }
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -44,7 +44,6 @@ public class SubGoal extends BaseEntity {
     @Column(name = "position", nullable = false)
     private int position;
 
-    @Builder
     public static SubGoal create(CoreGoal coreGoal, String title, int position) {
         return SubGoal.builder()
             .coreGoal(coreGoal)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -11,7 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
@@ -19,6 +22,9 @@ import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(access = AccessLevel.PROTECTED)
+@Table(name = "sub_goal")
 @Entity
 public class SubGoal extends BaseEntity {
 
@@ -32,30 +38,19 @@ public class SubGoal extends BaseEntity {
     @JoinColumn(name = "core_id", nullable = false)
     private CoreGoal coreGoal;
 
-    @Column(length = 30, nullable = false)
+    @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(name = "position", nullable = false)
     private int position;
 
-    private SubGoal(CoreGoal coreGoal, String title, int position) {
-        validateTitle(title);
-        this.coreGoal = coreGoal;
-        this.title = title;
-        this.position = position;
-    }
-
+    @Builder
     public static SubGoal create(CoreGoal coreGoal, String title, int position) {
-        return new SubGoal(coreGoal, title, position);
-    }
-
-    private void validateTitle(String title) {
-        if (title == null || title.isBlank()) {
-            throw new SubGoalException(TITLE_NOT_BLANK);
-        }
-        if (title.length() > MAX_TITLE_LENGTH) {
-            throw new SubGoalException(INVALID_TITLE_LENGTH);
-        }
+        return SubGoal.builder()
+            .coreGoal(coreGoal)
+            .title(title)
+            .position(position)
+            .build();
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -1,8 +1,5 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
-import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.INVALID_TITLE_LENGTH;
-import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.TITLE_NOT_BLANK;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
-import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -41,7 +37,7 @@ public class SubGoal extends BaseEntity {
     @Column(name = "title", length = MAX_TITLE_LENGTH, nullable = false)
     private String title;
 
-    @Column(name = "position", nullable = false)
+    @Column(name = "position", nullable = false, unique = true)
     private int position;
 
     public static SubGoal create(CoreGoal coreGoal, String title, int position) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CoreGoalErrorCode implements ErrorCode {
 
+    // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "상위 목표는 비어있을 수 없습니다."),
     INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "상위 목표는 30자를 넘을 수 없습니다.");
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CoreGoalErrorCode implements ErrorCode {
 
-    // TODO 에러 코드 별 메시지 관리. 추후 구현 시 아래 세미콜론 삭제
-    ;
+    TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "상위 목표는 비어있을 수 없습니다."),
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "상위 목표는 30자를 넘을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MandalartErrorCode implements ErrorCode {
 
-    // TODO 에러 코드 별 메시지 관리. 추후 구현 시 아래 세미콜론 삭제
-    ;
+    TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "최종 목표는 비어있을 수 없습니다."),
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "최종 목표는 30자를 넘을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MandalartErrorCode implements ErrorCode {
 
+    // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "최종 목표는 비어있을 수 없습니다."),
     INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "최종 목표는 30자를 넘을 수 없습니다.");
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SubGoalErrorCode implements ErrorCode {
 
+    // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "하위 목표는 비어있을 수 없습니다."),
     INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "하위 목표의 길이는 30자를 넘을 수 없습니다.");
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SubGoalErrorCode implements ErrorCode {
 
-    // TODO 에러 코드 별 메시지 관리. 추후 구현 시 아래 세미콜론 삭제
-    ;
+    TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "하위 목표는 비어있을 수 없습니다."),
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "하위 목표의 길이는 30자를 넘을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #18 

### ⭐️ 구현 내용
- [x] Mandalart 엔티티 기본 코드 생성
- [x] CoreGoal 엔티티 기본 코드 생성
- [x] SubGoal 엔티티 기본 코드 생성
- [x] History 엔티티 기본 코드 생성

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 만달아트, 핵심 목표, 세부 목표, 히스토리 엔티티에 제목, 위치, 생성 가능 여부 등 다양한 필드가 추가되고, 빌더 패턴을 통한 객체 생성 방식이 도입되었습니다.
  * 목표 완료 내역에 완료 날짜와 세부 목표 연동이 추가되었습니다.
  * 목표 주기(Cycle)로 일간, 주간, 1회성 옵션이 추가되었습니다.

* **버그 수정**
  * 목표 제목이 비어 있거나 30자를 초과할 경우 명확한 에러 메시지와 함께 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->