### PR TITLE
[FEAT] #31: 만다라트(전체 목표) 생성

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/global/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/dto/response/ApiResponse.java
@@ -26,6 +26,10 @@ public record ApiResponse<T, M>(int code, String message, T data, M meta) {
         return new ApiResponse<>(201, message, null, null);
     }
 
+    public static <T> ApiResponse<T, Void> created(T data, String message) {
+        return new ApiResponse<>(201, message, data, null);
+    }
+
     public static ApiResponse<Void, ErrorMeta> error(ErrorCode errorCode, ErrorMeta meta) {
         return new ApiResponse<>(errorCode.getStatus().value(), errorCode.getMessage(), null, meta);
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
@@ -1,10 +1,22 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.MandalartMessage.CREATED_SUCCESS;
+
+import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.mandalart.dto.request.MandalartCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.MandalartCreateResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.MandalartCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.MandalartQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class MandalartController {
@@ -12,4 +24,19 @@ public class MandalartController {
     private final MandalartCommandService mandalartCommandService;
     private final MandalartQueryService mandalartQueryService;
 
+    @PostMapping("/mandalarts")
+    public ResponseEntity<ApiResponse<MandalartCreateResponse, Void>> createMandalart(
+        @Valid @RequestBody MandalartCreateRequest createRequest
+    ) {
+        // TODO: 로그인 구현 완료 후 토큰에서 userId 획득
+        MandalartCreateResponse response = mandalartCommandService.createMandalart(
+            1L,
+            createRequest
+        );
+        Long mandalartId = response.id();
+        URI location = URI.create("/api/v1/mandalarts/" + mandalartId);
+
+        return ResponseEntity.created(location)
+            .body(ApiResponse.created(response, CREATED_SUCCESS));
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/MandalartMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/MandalartMessage.java
@@ -2,4 +2,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 
 public class MandalartMessage {
 
+    public static final String CREATED_SUCCESS = "만다라트가 등록되었습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/MandalartCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/MandalartCreateRequest.java
@@ -1,0 +1,12 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MandalartCreateRequest(
+    @NotBlank(message = "title은 필수 항목입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/MandalartCreateResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/MandalartCreateResponse.java
@@ -1,0 +1,13 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+
+public record MandalartCreateResponse(
+    Long id,
+    String title
+) {
+
+    public static MandalartCreateResponse from(Mandalart mandalart) {
+        return new MandalartCreateResponse(mandalart.getId(), mandalart.getTitle());
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/MandalartCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/MandalartCommandService.java
@@ -1,12 +1,46 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
+import static org.sopt36.ninedotserver.user.exception.UserErrorCode.USER_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+import org.sopt36.ninedotserver.mandalart.dto.request.MandalartCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.MandalartCreateResponse;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
+import org.sopt36.ninedotserver.user.domain.User;
+import org.sopt36.ninedotserver.user.exception.UserException;
+import org.sopt36.ninedotserver.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class MandalartCommandService {
 
+    private static final boolean AI_GENERATABLE = true;
+
     private final MandalartRepository mandalartRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public MandalartCreateResponse createMandalart(
+        Long userId,
+        MandalartCreateRequest mandalartCreateRequest
+    ) {
+        User user = getExistingUser(userId);
+        Mandalart mandalart = Mandalart.create(
+            user,
+            mandalartCreateRequest.title(),
+            AI_GENERATABLE
+        );
+
+        mandalartRepository.save(mandalart);
+
+        return MandalartCreateResponse.from(mandalart);
+    }
+
+    private User getExistingUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/user/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/user/exception/UserErrorCode.java
@@ -22,7 +22,10 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_BIRTHDAY_TYPE(HttpStatus.BAD_REQUEST, "생년월일은 yyyy.mm.dd 형태로 작성해야 합니다."),
 
     JOB_NOT_NULL(HttpStatus.BAD_REQUEST, "직업은 반드시 선택해야 합니다."),
-    INVALID_JOB_VALUE(HttpStatus.BAD_REQUEST, "직업 값이 올바르지 않습니다.");
+    INVALID_JOB_VALUE(HttpStatus.BAD_REQUEST, "직업 값이 올바르지 않습니다."),
+
+    // 404 NOT FOUND
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #31

### ⭐️ 구현 내용
- [x] 만다라트(전체 목표) 생성
- [x] ApiResponse에 Response body 포함한 created 생성

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
현재 로그인이 아직 구현되어있지 않아서 이후 헤더에 Authentication authentication 추가하고, userId 하드코딩한 부분 변경 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 만다라트 생성 API 엔드포인트(/api/v1/mandalarts)가 추가되어, 제목을 입력해 만다라트를 생성할 수 있습니다.
  * 만다라트 생성 요청 시 제목 필드에 대한 유효성 검사(공백 불가, 최대 30자)가 적용됩니다.
  * 만다라트 생성 성공 시 생성된 만다라트의 ID와 제목이 응답으로 반환됩니다.

* **버그 수정**
  * 존재하지 않는 유저로 만다라트 생성 시 적절한 에러 메시지와 상태 코드가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->