### PR TITLE
[FEAT] #27: create core goals

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode implements ErrorCode {
 
     // 400 Bad Request
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 경로의 파라미터는 올바른 형식이 아닙니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 '%s' 형식입니다."),
     MISSING_HEADER(HttpStatus.BAD_REQUEST, "요청 헤더 '%s'가 누락되었습니다."),
 
     // 404 Not Found

--- a/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt36/ninedotserver/global/exception/GlobalExceptionHandler.java
@@ -68,11 +68,12 @@ public class GlobalExceptionHandler {
         HttpServletRequest request
     ) {
         log.error("MethodArgumentTypeMismatchException 발생: {}", ex.getMessage());
+        String message = GlobalErrorCode.BAD_REQUEST.format(ex.getName());
 
         ErrorMeta meta = createMeta(request);
 
         return ResponseEntity.status(GlobalErrorCode.BAD_REQUEST.getStatus())
-            .body(ApiResponse.error(GlobalErrorCode.BAD_REQUEST, meta));
+            .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message, meta));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -37,7 +37,8 @@ public class CoreGoalController {
             createRequest
         );
         Long coreGoalId = response.id();
-        URI location = URI.create("/api/v1/mandalarts/" + mandalartId + "/core-goals" + coreGoalId);
+        URI location = URI.create(
+            "/api/v1/mandalarts/" + mandalartId + "/core-goals/" + coreGoalId);
 
         return ResponseEntity.created(location)
             .body(ApiResponse.created(response, CREATED_SUCCESS));

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -1,15 +1,46 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CREATED_SUCCESS;
+
+import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.CoreGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.CoreGoalQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class CoreGoalController {
 
     private final CoreGoalCommandService coreGoalCommandService;
     private final CoreGoalQueryService coreGoalQueryService;
+
+    // TODO 만다라트 상위 목표 생성
+    @PostMapping("/mandalarts/{mandalartId}/core-goals")
+    public ResponseEntity<ApiResponse<CoreGoalCreateResponse, Void>> createCoreGoal(
+        @PathVariable Long mandalartId,
+        @Valid @RequestBody CoreGoalCreateRequest createRequest
+    ) {
+        Long userId = 1L; // TODO 로그인 구현 완료 후 Authentication 에서 가져오도록 변경
+        CoreGoalCreateResponse response = coreGoalCommandService.createCoreGoal(userId,
+            mandalartId,
+            createRequest
+        );
+        Long coreGoalId = response.id();
+        URI location = URI.create("/api/v1/mandalarts/" + mandalartId + "/core-goals" + coreGoalId);
+
+        return ResponseEntity.created(location)
+            .body(ApiResponse.created(response, CREATED_SUCCESS));
+    }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
@@ -2,4 +2,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 
 public class CoreGoalMessage {
 
+    public static final String CREATED_SUCCESS = "성공적으로 해당 만다라트에 상위 목표를 추가했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -1,5 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.INVALID_MANDALART_USER;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.sopt36.ninedotserver.global.entity.BaseEntity;
+import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.user.domain.User;
 
 @Getter
@@ -51,5 +54,11 @@ public class Mandalart extends BaseEntity {
             .title(title)
             .aiGeneratable(aiGeneratable)
             .build();
+    }
+
+    public void ensureOwnedBy(Long userId) {
+        if (!user.isSameId(userId)) {
+            throw new MandalartException(INVALID_MANDALART_USER);
+        }
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Mandalart.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
 import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.INVALID_MANDALART_USER;
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_USER_REQUIRED;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,6 +58,17 @@ public class Mandalart extends BaseEntity {
     }
 
     public void ensureOwnedBy(Long userId) {
+        requireUserId(userId);
+        checkOwnership(userId);
+    }
+
+    private void requireUserId(Long userId) {
+        if (userId == null) {
+            throw new MandalartException(MANDALART_USER_REQUIRED);
+        }
+    }
+
+    private void checkOwnership(Long userId) {
         if (!user.isSameId(userId)) {
             throw new MandalartException(INVALID_MANDALART_USER);
         }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/CoreGoalCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/CoreGoalCreateRequest.java
@@ -1,0 +1,18 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CoreGoalCreateRequest(
+    @Min(value = 1, message = "position은 1 이상 8 이하의 값이어야 합니다.")
+    @Max(value = 8, message = "position은 1 이상 8 이하의 값이어야 합니다.")
+    int position,
+
+    @NotBlank(message = "title은 필수 항목입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalCreateResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalCreateResponse.java
@@ -1,0 +1,12 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
+
+public record CoreGoalCreateResponse(
+    Long id
+) {
+
+    public static CoreGoalCreateResponse from(CoreGoal coreGoal) {
+        return new CoreGoalCreateResponse(coreGoal.getId());
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
@@ -9,7 +9,11 @@ public enum CoreGoalErrorCode implements ErrorCode {
 
     // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "상위 목표는 비어있을 수 없습니다."),
-    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "상위 목표는 30자를 넘을 수 없습니다.");
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "상위 목표는 30자를 넘을 수 없습니다."),
+
+    // 409 Conflict
+    CORE_GOAL_CONFLICT(HttpStatus.CONFLICT, "이미 만다라트의 해당 위치에 상위 목표가 작성되어 있습니다."),
+    CORE_GOAL_COMPLETED(HttpStatus.CONFLICT, "이미 해당 만다라트의 상위 목표 8개를 모두 작성하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
@@ -9,7 +9,13 @@ public enum MandalartErrorCode implements ErrorCode {
 
     // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "최종 목표는 비어있을 수 없습니다."),
-    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "최종 목표는 30자를 넘을 수 없습니다.");
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "최종 목표는 30자를 넘을 수 없습니다."),
+
+    // 403 FORBIDDEN
+    INVALID_MANDALART_USER(HttpStatus.FORBIDDEN, "다른 유저의 만다라트를 조회할 수 없습니다."),
+
+    // 404 NOT FOUND
+    MANDALART_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 만다라트입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/MandalartErrorCode.java
@@ -10,6 +10,7 @@ public enum MandalartErrorCode implements ErrorCode {
     // 400 BAD Request
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "최종 목표는 비어있을 수 없습니다."),
     INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "최종 목표는 30자를 넘을 수 없습니다."),
+    MANDALART_USER_REQUIRED(HttpStatus.BAD_REQUEST, "유저 정보는 비어있을 수 없습니다."),
 
     // 403 FORBIDDEN
     INVALID_MANDALART_USER(HttpStatus.FORBIDDEN, "다른 유저의 만다라트를 조회할 수 없습니다."),

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepository.java
@@ -8,4 +8,7 @@ import org.springframework.stereotype.Repository;
 public interface CoreGoalRepository
     extends JpaRepository<CoreGoal, Long>, CoreGoalRepositoryCustom {
 
+    int countCoreGoalByMandalartId(Long mandalartId);
+
+    boolean existsByMandalartIdAndPosition(Long mandalartId, int position);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
@@ -1,17 +1,76 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
+import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.CORE_GOAL_COMPLETED;
+import static org.sopt36.ninedotserver.mandalart.exception.CoreGoalErrorCode.CORE_GOAL_CONFLICT;
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.ai.service.AiRecommendationService;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalCreateResponse;
+import org.sopt36.ninedotserver.mandalart.exception.CoreGoalException;
+import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class CoreGoalCommandService {
 
+    private static final int MAX_MANDALART = 8;
+    private static final boolean AI_GENERATABLE = true;
+
     private final CoreGoalRepository coreGoalRepository;
     private final MandalartRepository mandalartRepository;
     private final AiRecommendationService aiRecommendationService;
 
+    @Transactional
+    public CoreGoalCreateResponse createCoreGoal(
+        Long userId,
+        Long mandalartId,
+        CoreGoalCreateRequest coreGoalCreateRequest
+    ) {
+        Mandalart mandalart = getExistingMandalart(mandalartId);
+        validate(mandalart, userId, mandalartId, coreGoalCreateRequest);
+
+        CoreGoal coreGoal = CoreGoal.create(mandalart,
+            coreGoalCreateRequest.title(),
+            coreGoalCreateRequest.position(),
+            AI_GENERATABLE
+        );
+        coreGoalRepository.save(coreGoal);
+
+        return CoreGoalCreateResponse.from(coreGoal);
+    }
+
+    private void validate(Mandalart mandalart, Long userId, Long mandalartId,
+        CoreGoalCreateRequest coreGoalCreateRequest) {
+        mandalart.ensureOwnedBy(userId);
+        validateCoreGoalLimitNotExceeded(mandalartId);
+        validateAlreadyExists(mandalartId, coreGoalCreateRequest);
+    }
+
+    private Mandalart getExistingMandalart(Long mandalartId) {
+        return mandalartRepository.findById(mandalartId)
+            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+    }
+
+    private void validateCoreGoalLimitNotExceeded(Long mandalartId) {
+        if (coreGoalRepository.countCoreGoalByMandalartId(mandalartId) == MAX_MANDALART) {
+            throw new CoreGoalException(CORE_GOAL_COMPLETED);
+        }
+    }
+
+    private void validateAlreadyExists(Long mandalartId,
+        CoreGoalCreateRequest coreGoalCreateRequest
+    ) {
+        if (coreGoalRepository.existsByMandalartIdAndPosition(mandalartId,
+            coreGoalCreateRequest.position())) {
+            throw new CoreGoalException(CORE_GOAL_CONFLICT);
+        }
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/user/domain/User.java
+++ b/src/main/java/org/sopt36/ninedotserver/user/domain/User.java
@@ -57,11 +57,15 @@ public class User extends BaseEntity {
     public static User create(String name, String email, String profileImageUrl, String birthday,
         JobType job) {
         return User.builder()
-                   .name(name)
-                   .email(email)
-                   .profileImageUrl(profileImageUrl)
-                   .birthday(birthday)
-                   .job(job)
-                   .build();
+            .name(name)
+            .email(email)
+            .profileImageUrl(profileImageUrl)
+            .birthday(birthday)
+            .job(job)
+            .build();
+    }
+
+    public boolean isSameId(Long id) {
+        return this.id.equals(id);
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/user/domain/User.java
+++ b/src/main/java/org/sopt36/ninedotserver/user/domain/User.java
@@ -66,6 +66,9 @@ public class User extends BaseEntity {
     }
 
     public boolean isSameId(Long id) {
+        if (id == null) {
+            return false;
+        }
         return this.id.equals(id);
     }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #27

### ⭐️ 구현 내용
- [x] 상위 목표 생성 API 구현
- [x] GlobalExceptionHandler에서 타입 불일치 오류 시 메시지 수정

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
만다라트 도메인에 구현한 검증 로직이 찬민오빠가 추가할 로직과 겹칠 수도 있을 거 같네용...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 만다라트에 상위 목표(Core Goal)를 생성하는 신규 API 엔드포인트가 추가되었습니다.
  * 상위 목표 생성 시 위치와 제목에 대한 입력값 유효성 검사가 적용됩니다.
  * 상위 목표 생성 시 중복 위치, 최대 개수(8개) 초과 등 상황에 맞는 에러 메시지가 제공됩니다.
  * 상위 목표 생성 성공 시 성공 메시지가 반환됩니다.

* **버그 수정**
  * 잘못된 요청 파라미터에 대해 더 구체적인 에러 메시지가 반환됩니다.

* **개선**
  * 만다라트 소유자 검증 및 존재하지 않는 만다라트 접근 시 적절한 에러 메시지가 추가되었습니다.
  * 사용자 ID 비교 기능이 추가되어 소유자 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->