### PR TITLE
[FEAT] #29: 상위 목표 id 리스트 반환

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CREATED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.IDS_RETRIEVED_SUCCESS;
 
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -8,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalCreateResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalIdsResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.CoreGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.CoreGoalQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +28,6 @@ public class CoreGoalController {
     private final CoreGoalCommandService coreGoalCommandService;
     private final CoreGoalQueryService coreGoalQueryService;
 
-    // TODO 만다라트 상위 목표 생성
     @PostMapping("/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<CoreGoalCreateResponse, Void>> createCoreGoal(
         @PathVariable Long mandalartId,
@@ -42,6 +44,16 @@ public class CoreGoalController {
 
         return ResponseEntity.created(location)
             .body(ApiResponse.created(response, CREATED_SUCCESS));
+    }
+
+    @GetMapping("/mandalarts/{mandalartId}/core-goals")
+    public ResponseEntity<ApiResponse<CoreGoalIdsResponse, Void>> getCoreGoalIds(
+        @PathVariable Long mandalartId
+    ) {
+        Long userId = 2L; // TODO 로그인 구현 완료 후 Authentication 에서 가져오도록 변경
+        CoreGoalIdsResponse response = coreGoalQueryService.getCoreGoalIds(userId, mandalartId);
+
+        return ResponseEntity.ok(ApiResponse.ok(IDS_RETRIEVED_SUCCESS, response));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -50,7 +50,7 @@ public class CoreGoalController {
     public ResponseEntity<ApiResponse<CoreGoalIdsResponse, Void>> getCoreGoalIds(
         @PathVariable Long mandalartId
     ) {
-        Long userId = 2L; // TODO 로그인 구현 완료 후 Authentication 에서 가져오도록 변경
+        Long userId = 1L; // TODO 로그인 구현 완료 후 Authentication 에서 가져오도록 변경
         CoreGoalIdsResponse response = coreGoalQueryService.getCoreGoalIds(userId, mandalartId);
 
         return ResponseEntity.ok(ApiResponse.ok(IDS_RETRIEVED_SUCCESS, response));

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
@@ -3,4 +3,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 public class CoreGoalMessage {
 
     public static final String CREATED_SUCCESS = "성공적으로 해당 만다라트에 상위 목표를 추가했습니다.";
+    public static final String IDS_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표 id들을 조회했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalIdResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalIdResponse.java
@@ -1,0 +1,10 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
+
+public record CoreGoalIdResponse(Long id, int position) {
+
+    public static CoreGoalIdResponse from(CoreGoal coreGoal) {
+        return new CoreGoalIdResponse(coreGoal.getId(), coreGoal.getPosition());
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalIdsResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalIdsResponse.java
@@ -1,0 +1,10 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+
+public record CoreGoalIdsResponse(List<CoreGoalIdResponse> coreGoalIds) {
+
+    public static CoreGoalIdsResponse of(List<CoreGoalIdResponse> ids) {
+        return new CoreGoalIdsResponse(List.copyOf(ids));
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepository.java
@@ -1,5 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
+import java.util.List;
 import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ public interface CoreGoalRepository
     int countCoreGoalByMandalartId(Long mandalartId);
 
     boolean existsByMandalartIdAndPosition(Long mandalartId, int position);
+
+    List<CoreGoal> findAllByMandalartIdOrderByPosition(Long mandalartId);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
@@ -35,7 +35,7 @@ public class CoreGoalCommandService {
         CoreGoalCreateRequest coreGoalCreateRequest
     ) {
         Mandalart mandalart = getExistingMandalart(mandalartId);
-        validate(mandalart, userId, mandalartId, coreGoalCreateRequest);
+        validate(mandalart, userId, coreGoalCreateRequest);
 
         CoreGoal coreGoal = CoreGoal.create(mandalart,
             coreGoalCreateRequest.title(),
@@ -47,16 +47,18 @@ public class CoreGoalCommandService {
         return CoreGoalCreateResponse.from(coreGoal);
     }
 
-    private void validate(Mandalart mandalart, Long userId, Long mandalartId,
-        CoreGoalCreateRequest coreGoalCreateRequest) {
-        mandalart.ensureOwnedBy(userId);
-        validateCoreGoalLimitNotExceeded(mandalartId);
-        validateAlreadyExists(mandalartId, coreGoalCreateRequest);
-    }
-
     private Mandalart getExistingMandalart(Long mandalartId) {
         return mandalartRepository.findById(mandalartId)
             .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+    }
+
+    private void validate(Mandalart mandalart,
+        Long userId,
+        CoreGoalCreateRequest coreGoalCreateRequest
+    ) {
+        mandalart.ensureOwnedBy(userId);
+        validateCoreGoalLimitNotExceeded(mandalart.getId());
+        validateAlreadyExists(mandalart.getId(), coreGoalCreateRequest);
     }
 
     private void validateCoreGoalLimitNotExceeded(Long mandalartId) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/CoreGoalQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/CoreGoalQueryService.java
@@ -1,6 +1,13 @@
 package org.sopt36.ninedotserver.mandalart.service.query;
 
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalIdResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalIdsResponse;
+import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
 import org.springframework.stereotype.Service;
@@ -13,5 +20,27 @@ public class CoreGoalQueryService {
 
     private final CoreGoalRepository coreGoalRepository;
     private final MandalartRepository mandalartRepository;
+
+    public CoreGoalIdsResponse getCoreGoalIds(Long userId, Long mandalartId) {
+        Mandalart mandalart = getExistingMandalart(mandalartId);
+        mandalart.ensureOwnedBy(userId);
+
+        List<CoreGoalIdResponse> ids = findCoreGoalIds(mandalartId);
+
+        return CoreGoalIdsResponse.of(ids);
+    }
+
+    private Mandalart getExistingMandalart(Long mandalartId) {
+        return mandalartRepository.findById(mandalartId)
+            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+    }
+
+    private List<CoreGoalIdResponse> findCoreGoalIds(Long mandalartId) {
+        return coreGoalRepository
+            .findAllByMandalartIdOrderByPosition(mandalartId)
+            .stream()
+            .map(CoreGoalIdResponse::from)
+            .toList();
+    }
 
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #29

### ⭐️ 구현 내용
- [x] 상위 목표 id 리스트 반환 로직 구현

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
해당 로직은 Jpa 기본 제공 함수로도 충분하다고 판단하여 querydsl 사용하지 않았습니다. querydsl은 동적 필터링, 복잡한 조건, 조인, 페이징 등에 사용할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 만다라트의 상위 목표 ID 목록을 조회할 수 있는 새로운 조회( GET ) 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 기존 상위 목표 생성 기능에서 불필요한 주석이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->