### PR TITLE
Feat/#36 만다라트 하위 목표 생성

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -1,11 +1,15 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_CREATE_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_ID_LIST_FETCH_SUCCESS;
 
+import jakarta.validation.Valid;
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.SubGoalCommandService;
@@ -13,6 +17,8 @@ import org.sopt36.ninedotserver.mandalart.service.query.SubGoalQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,9 +38,28 @@ public class SubGoalController {
         List<SubGoalIdResponse> subGoalIds = subGoalQueryService.getSubGoalIds(userId, coreGoalId);
         return ResponseEntity.ok()
             .body(ApiResponse.ok(
-                SUB_GOAL_ID_LIST_FETCH_SUCCESS,
-                SubGoalIdListResponse.from(subGoalIds)
-            )
+                    SUB_GOAL_ID_LIST_FETCH_SUCCESS,
+                    SubGoalIdListResponse.from(subGoalIds)
+                )
+            );
+    }
+
+    @PostMapping("/{coreGoalId}/sub-goals")
+    public ResponseEntity<ApiResponse<SubGoalCreateResponse, Void>> createSubGoal(
+        @PathVariable Long coreGoalId,
+        @Valid @RequestBody SubGoalCreateRequest request
+    ) {
+        Long userId = 1L;
+        SubGoalCreateResponse response = subGoalCommandService.createSubGoal(
+            userId,
+            coreGoalId,
+            request
         );
+
+        URI location = URI.create(
+            "/api/v1/core-goals/" + coreGoalId + "/sub-goals/" + response.id());
+
+        return ResponseEntity.created(location)
+            .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
@@ -3,4 +3,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 public class SubGoalMessage {
 
     public static final String SUB_GOAL_ID_LIST_FETCH_SUCCESS = "성공적으로 해당 상위 목표의 하위 목표 ID 리스트를 조회했습니다.";
+    public static final String SUB_GOAL_CREATE_SUCCESS = "성공적으로 해당 만다라트에 하위 목표를 추가했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -2,6 +2,8 @@ package org.sopt36.ninedotserver.mandalart.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,6 +27,7 @@ import org.sopt36.ninedotserver.global.entity.BaseEntity;
 public class SubGoal extends BaseEntity {
 
     private static final int MAX_TITLE_LENGTH = 30;
+    private static final int MAX_CYCLE_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,11 +43,20 @@ public class SubGoal extends BaseEntity {
     @Column(name = "position", nullable = false)
     private int position;
 
-    public static SubGoal create(CoreGoal coreGoal, String title, int position) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cycle", length = MAX_CYCLE_LENGTH, nullable = false)
+    private Cycle cycle;
+
+    public static SubGoal create(CoreGoal coreGoal,
+        String title,
+        int position,
+        Cycle cycle
+    ) {
         return SubGoal.builder()
             .coreGoal(coreGoal)
             .title(title)
             .position(position)
+            .cycle(cycle)
             .build();
     }
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalCreateRequest.java
@@ -1,0 +1,23 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.sopt36.ninedotserver.mandalart.domain.Cycle;
+
+public record SubGoalCreateRequest(
+    @NotBlank(message = "title은 필수 입력 항목입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title,
+
+    @Min(value = 1, message = "position은 1 이상 8 이하의 값이어야 합니다.")
+    @Max(value = 8, message = "position은 1 이상 8 이하의 값이어야 합니다.")
+    int position,
+
+    @NotNull(message = "cycle은 필수 입력값입니다.")
+    Cycle cycle
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalCreateResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalCreateResponse.java
@@ -1,0 +1,13 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.SubGoal;
+
+public record SubGoalCreateResponse(
+    Long id
+) {
+
+    public static SubGoalCreateResponse from(SubGoal subgoal) {
+        return new SubGoalCreateResponse(subgoal.getId());
+    }
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
@@ -15,7 +15,11 @@ public enum SubGoalErrorCode implements ErrorCode {
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "해당 하위 목표에 접근할 권한이 없습니다."),
 
     // 404 Not Found
-    CORE_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상위 목표입니다.");
+    CORE_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상위 목표입니다."),
+
+    // 409 Conflict
+    SUB_GOAL_COMPLETED(HttpStatus.CONFLICT, "이미 해당 상위 목표의 하위 목표 8개를 모두 작성하였습니다."),
+    SUB_GOAL_CONFLICT(HttpStatus.CONFLICT, "이미 해당 위치에 하위 목표가 존재합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalRepository.java
@@ -10,4 +10,8 @@ public interface SubGoalRepository extends JpaRepository<SubGoal, Long>, SubGoal
 
     List<SubGoal> findAllByCoreGoalId(Long coreGoalId);
 
+    int countByCoreGoalId(Long coreGoalId);
+
+    boolean existsByCoreGoalIdAndPosition(Long coreGoalId, int position);
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -1,16 +1,70 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_COMPLETED;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_CONFLICT;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.ai.service.AiRecommendationService;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
+import org.sopt36.ninedotserver.mandalart.domain.SubGoal;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
+import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.SubGoalRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class SubGoalCommandService {
 
+    private static final int MAX_SUB_GOALS = 8;
+
     private final SubGoalRepository subGoalRepository;
     private final CoreGoalRepository coreGoalRepository;
     private final AiRecommendationService aiRecommendationService;
+
+    @Transactional
+    public SubGoalCreateResponse createSubGoal(Long userId, Long coreGoalId,
+        SubGoalCreateRequest request) {
+
+        CoreGoal coreGoal = getExistingCoreGoal(coreGoalId);
+        validate(coreGoal, userId, request);
+
+        SubGoal subGoal = SubGoal.create(
+            coreGoal,
+            request.title(),
+            request.position(),
+            request.cycle()
+        );
+
+        subGoalRepository.save(subGoal);
+        return SubGoalCreateResponse.from(subGoal);
+    }
+
+    private void validate(CoreGoal coreGoal, Long userId, SubGoalCreateRequest request) {
+        coreGoal.verifyUser(userId);
+        validateSubGoalLimitNotExceeded(coreGoal.getId());
+        validateAlreadyExists(coreGoal.getId(), request.position());
+    }
+
+    private CoreGoal getExistingCoreGoal(Long coreGoalId) {
+        return coreGoalRepository.findById(coreGoalId)
+            .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
+
+    }
+
+    private void validateSubGoalLimitNotExceeded(Long coreGoalId) {
+        if (subGoalRepository.countByCoreGoalId(coreGoalId) >= MAX_SUB_GOALS) {
+            throw new SubGoalException(SUB_GOAL_COMPLETED);
+        }
+    }
+
+    private void validateAlreadyExists(Long coreGoalId, int position) {
+        if (subGoalRepository.existsByCoreGoalIdAndPosition(coreGoalId, position)) {
+            throw new SubGoalException(SUB_GOAL_CONFLICT);
+        }
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -41,6 +41,7 @@ public class SubGoalCommandService {
         );
 
         subGoalRepository.save(subGoal);
+
         return SubGoalCreateResponse.from(subGoal);
     }
 
@@ -53,7 +54,6 @@ public class SubGoalCommandService {
     private CoreGoal getExistingCoreGoal(Long coreGoalId) {
         return coreGoalRepository.findById(coreGoalId)
             .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
-
     }
 
     private void validateSubGoalLimitNotExceeded(Long coreGoalId) {


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #36

### ⭐️ 구현 내용
- [ ] 만다라트 하위 목표 생성 api 구현

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 만다라트의 핵심 목표에 하위 목표(서브골)를 추가할 수 있는 기능이 도입되었습니다. 하위 목표 생성 시 제목, 위치, 주기를 입력하며, 유효성 검사가 적용됩니다.
  * 하위 목표 생성 성공 시 성공 메시지와 함께 생성된 하위 목표의 ID가 반환됩니다.

* **버그 수정**
  * 동일 위치에 하위 목표가 이미 존재하거나 최대 하위 목표(8개)를 초과할 경우 적절한 오류 메시지가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->