### PR TITLE
Feat/#43 하위 목표 수정/삭제 api 구현

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -2,6 +2,7 @@ package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_CREATE_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_ID_LIST_FETCH_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_UPDATE_SUCCESS;
 
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -9,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalUpdateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
@@ -16,13 +18,14 @@ import org.sopt36.ninedotserver.mandalart.service.command.SubGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.SubGoalQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/v1/core-goals")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class SubGoalController {
@@ -30,7 +33,7 @@ public class SubGoalController {
     private final SubGoalCommandService subGoalCommandService;
     private final SubGoalQueryService subGoalQueryService;
 
-    @GetMapping("/{coreGoalId}/sub-goals")
+    @GetMapping("/core-goals/{coreGoalId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalIdListResponse, Void>> getSubGoalIds(
         @PathVariable Long coreGoalId
     ) {
@@ -44,7 +47,7 @@ public class SubGoalController {
             );
     }
 
-    @PostMapping("/{coreGoalId}/sub-goals")
+    @PostMapping("/core-goals/{coreGoalId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalCreateResponse, Void>> createSubGoal(
         @PathVariable Long coreGoalId,
         @Valid @RequestBody SubGoalCreateRequest request
@@ -62,4 +65,18 @@ public class SubGoalController {
         return ResponseEntity.created(location)
             .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
     }
+
+    @PatchMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<ApiResponse<Void, Void>> updateSubGoal(
+        @PathVariable Long subGoalId,
+        @Valid @RequestBody SubGoalUpdateRequest request
+    ) {
+        Long userId = 1L; // TODO: 로그인 구현되면 token에서 사용자id 가져오기
+
+        subGoalCommandService.updateSubGoal(userId, subGoalId, request);
+
+        return ResponseEntity.ok()
+            .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
+    }
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_CREATE_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_DELETE_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_ID_LIST_FETCH_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_UPDATE_SUCCESS;
 
@@ -17,6 +18,7 @@ import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.SubGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.SubGoalQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -77,6 +79,19 @@ public class SubGoalController {
 
         return ResponseEntity.ok()
             .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
+    }
+
+    @DeleteMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<ApiResponse<Void, Void>> deleteSubGoal(
+        @PathVariable Long subGoalId
+    ) {
+        Long userId = 1L; // TODO: 로그인 구현되면 token에서 사용자id 가져오기
+
+        subGoalCommandService.deleteSubGoal(userId, subGoalId);
+
+        return ResponseEntity.ok()
+            .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
+
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
@@ -4,4 +4,5 @@ public class SubGoalMessage {
 
     public static final String SUB_GOAL_ID_LIST_FETCH_SUCCESS = "성공적으로 해당 상위 목표의 하위 목표 ID 리스트를 조회했습니다.";
     public static final String SUB_GOAL_CREATE_SUCCESS = "성공적으로 해당 만다라트에 하위 목표를 추가했습니다.";
+    public static final String SUB_GOAL_UPDATE_SUCCESS = "성공적으로 해당 하위 목표의 내용을 수정했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
@@ -5,4 +5,5 @@ public class SubGoalMessage {
     public static final String SUB_GOAL_ID_LIST_FETCH_SUCCESS = "성공적으로 해당 상위 목표의 하위 목표 ID 리스트를 조회했습니다.";
     public static final String SUB_GOAL_CREATE_SUCCESS = "성공적으로 해당 만다라트에 하위 목표를 추가했습니다.";
     public static final String SUB_GOAL_UPDATE_SUCCESS = "성공적으로 해당 하위 목표의 내용을 수정했습니다.";
+    public static final String SUB_GOAL_DELETE_SUCCESS = "성공적으로 해당 하위 목표의 내용을 삭제했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/SubGoal.java
@@ -60,4 +60,13 @@ public class SubGoal extends BaseEntity {
             .build();
     }
 
+    public void verifyUser(Long userId) {
+        this.coreGoal.verifyUser(userId);
+    }
+
+    public void update(String title, Cycle cycle) {
+        this.title = title;
+        this.cycle = cycle;
+    }
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalCreateRequest.java
@@ -3,7 +3,6 @@ package org.sopt36.ninedotserver.mandalart.dto.request;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.sopt36.ninedotserver.mandalart.domain.Cycle;
 
@@ -16,7 +15,7 @@ public record SubGoalCreateRequest(
     @Max(value = 8, message = "position은 1 이상 8 이하의 값이어야 합니다.")
     int position,
 
-    @NotNull(message = "cycle은 필수 입력값입니다.")
+    @NotBlank(message = "cycle은 필수 입력값입니다.")
     Cycle cycle
 ) {
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalUpdateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalUpdateRequest.java
@@ -1,0 +1,17 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.sopt36.ninedotserver.mandalart.domain.Cycle;
+
+public record SubGoalUpdateRequest(
+    @NotBlank(message = "title은 필수 입력값입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title,
+
+    @NotNull(message = "cycle은 필수 입력값입니다.")
+    Cycle cycle
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalUpdateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalUpdateRequest.java
@@ -1,7 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.sopt36.ninedotserver.mandalart.domain.Cycle;
 
@@ -10,7 +9,7 @@ public record SubGoalUpdateRequest(
     @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
     String title,
 
-    @NotNull(message = "cycle은 필수 입력값입니다.")
+    @NotBlank(message = "cycle은 필수 입력값입니다.")
     Cycle cycle
 ) {
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
@@ -16,6 +16,7 @@ public enum SubGoalErrorCode implements ErrorCode {
 
     // 404 Not Found
     CORE_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상위 목표입니다."),
+    SUB_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 하위 목표입니다."),
 
     // 409 Conflict
     SUB_GOAL_COMPLETED(HttpStatus.CONFLICT, "이미 해당 상위 목표의 하위 목표 8개를 모두 작성하였습니다."),

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -3,12 +3,14 @@ package org.sopt36.ninedotserver.mandalart.service.command;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_COMPLETED;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_CONFLICT;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.ai.service.AiRecommendationService;
 import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoal;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalUpdateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
@@ -31,7 +33,7 @@ public class SubGoalCommandService {
         SubGoalCreateRequest request) {
 
         CoreGoal coreGoal = getExistingCoreGoal(coreGoalId);
-        validate(coreGoal, userId, request);
+        validateCreate(coreGoal, userId, request);
 
         SubGoal subGoal = SubGoal.create(
             coreGoal,
@@ -45,7 +47,14 @@ public class SubGoalCommandService {
         return SubGoalCreateResponse.from(subGoal);
     }
 
-    private void validate(CoreGoal coreGoal, Long userId, SubGoalCreateRequest request) {
+    @Transactional
+    public void updateSubGoal(Long userId, Long subGoalId, SubGoalUpdateRequest request) {
+        SubGoal subGoal = getExistingSubGoal(subGoalId);
+        subGoal.verifyUser(userId);
+        subGoal.update(request.title(), request.cycle());
+    }
+
+    private void validateCreate(CoreGoal coreGoal, Long userId, SubGoalCreateRequest request) {
         coreGoal.verifyUser(userId);
         validateSubGoalLimitNotExceeded(coreGoal.getId());
         validateAlreadyExists(coreGoal.getId(), request.position());
@@ -67,4 +76,11 @@ public class SubGoalCommandService {
             throw new SubGoalException(SUB_GOAL_CONFLICT);
         }
     }
+
+    private SubGoal getExistingSubGoal(Long subGoalId) {
+        return subGoalRepository.findById(subGoalId)
+            .orElseThrow(() -> new SubGoalException(SUB_GOAL_NOT_FOUND));
+    }
+
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -54,6 +54,13 @@ public class SubGoalCommandService {
         subGoal.update(request.title(), request.cycle());
     }
 
+    @Transactional
+    public void deleteSubGoal(Long userId, Long subGoalId) {
+        SubGoal subGoal = getExistingSubGoal(subGoalId);
+        subGoal.verifyUser(userId);
+        subGoalRepository.delete(subGoal);
+    }
+
     private void validateCreate(CoreGoal coreGoal, Long userId, SubGoalCreateRequest request) {
         coreGoal.verifyUser(userId);
         validateSubGoalLimitNotExceeded(coreGoal.getId());
@@ -81,6 +88,7 @@ public class SubGoalCommandService {
         return subGoalRepository.findById(subGoalId)
             .orElseThrow(() -> new SubGoalException(SUB_GOAL_NOT_FOUND));
     }
+
 
 
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #43

### ⭐️ 구현 내용
- [x] 하위 목표 수정 api 구현
- [x] 하위 목표 삭제 api 구현

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 하위 목표(서브골) 수정 및 삭제 기능이 추가되었습니다.  
  * 하위 목표 수정 시 제목과 주기를 변경할 수 있습니다.
  * 하위 목표가 존재하지 않을 경우 알맞은 오류 메시지가 제공됩니다.

* **버그 수정**
  * 하위 목표 관련 요청 경로가 명확하게 정비되었습니다.

* **문서화**
  * 하위 목표 수정/삭제 성공 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->