### PR TITLE
[FEAT] #50: 온보딩 시 상위 목표 수정

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -2,18 +2,21 @@ package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.IDS_RETRIEVED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.ONBOARDING_UPDATED_SUCCESS;
 
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalUpdateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalIdsResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.CoreGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.CoreGoalQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,4 +59,14 @@ public class CoreGoalController {
         return ResponseEntity.ok(ApiResponse.ok(IDS_RETRIEVED_SUCCESS, response));
     }
 
+    @PatchMapping("/core-goals/{coreGoalId}")
+    public ResponseEntity<ApiResponse<Void, Void>> updateCoreGoal(
+        @PathVariable Long coreGoalId,
+        @Valid @RequestBody CoreGoalUpdateRequest updateRequest
+    ) {
+        Long userId = 1L;
+        coreGoalCommandService.updateCoreGoal(userId, coreGoalId, updateRequest);
+
+        return ResponseEntity.ok(ApiResponse.ok(ONBOARDING_UPDATED_SUCCESS));
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
@@ -4,4 +4,5 @@ public class CoreGoalMessage {
 
     public static final String CREATED_SUCCESS = "성공적으로 해당 만다라트에 상위 목표를 추가했습니다.";
     public static final String IDS_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표 id들을 조회했습니다.";
+    public static final String ONBOARDING_UPDATED_SUCCESS = "성공적으로 해당 상위 목표의 내용을 수정하였습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/CoreGoal.java
@@ -64,4 +64,8 @@ public class CoreGoal extends BaseEntity {
         mandalart.ensureOwnedBy(userId);
     }
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/CoreGoalUpdateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/CoreGoalUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CoreGoalUpdateRequest(
+    @NotBlank(message = "title은 필수 항목입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/CoreGoalErrorCode.java
@@ -11,6 +11,9 @@ public enum CoreGoalErrorCode implements ErrorCode {
     TITLE_NOT_BLANK(HttpStatus.BAD_REQUEST, "상위 목표는 비어있을 수 없습니다."),
     INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "상위 목표는 30자를 넘을 수 없습니다."),
 
+    // 404 NOT FOUND
+    CORE_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상위 목표를 찾을 수 없습니다."),
+
     // 409 Conflict
     CORE_GOAL_CONFLICT(HttpStatus.CONFLICT, "이미 만다라트의 해당 위치에 상위 목표가 작성되어 있습니다."),
     CORE_GOAL_COMPLETED(HttpStatus.CONFLICT, "이미 해당 만다라트의 상위 목표 8개를 모두 작성하였습니다.");


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #50

### ⭐️ 구현 내용
- [x] 온보딩 시 상위 목표 수정

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
근데 지금 보니까 DTO 단에서 검증할 때 Message를 에러코드에 있는 거 갖다 쓰도록 해도 될 것 같다는 생각이 드는데 어떻게 생각하시나요들?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 상위 목표(Core Goal) 내용을 수정할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  * 상위 목표의 제목을 30자 이내로 수정할 수 있습니다.

* **버그 수정**
  * 상위 목표가 존재하지 않을 경우 404 오류 메시지가 제공됩니다.

* **문서화**
  * 상위 목표 수정 성공 시 안내 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->