### PR TITLE
[FEAT] #51: 온보딩 시 상위 목표 삭제 api 구현

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -3,6 +3,7 @@ package org.sopt36.ninedotserver.mandalart.controller;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_IDS_RETRIEVED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_LIST_RETRIEVED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_ONBOARDING_DELETED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_ONBOARDING_UPDATED_SUCCESS;
 
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalsResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.CoreGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.CoreGoalQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -80,6 +82,16 @@ public class CoreGoalController {
         coreGoalCommandService.updateCoreGoal(userId, coreGoalId, updateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_ONBOARDING_UPDATED_SUCCESS));
+    }
+
+    @DeleteMapping("/core-goals/{coreGoalId}")
+    public ResponseEntity<ApiResponse<Void, Void>> deleteCoreGoal(
+        @PathVariable Long coreGoalId
+    ) {
+        Long userId = 1L;
+        coreGoalCommandService.deleteCoreGoal(userId, coreGoalId);
+
+        return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_ONBOARDING_DELETED_SUCCESS));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -35,7 +35,7 @@ public class CoreGoalController {
     private final CoreGoalCommandService coreGoalCommandService;
     private final CoreGoalQueryService coreGoalQueryService;
 
-    @PostMapping("/mandalarts/{mandalartId}/core-goals")
+    @PostMapping("/onboarding/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<CoreGoalCreateResponse, Void>> createCoreGoal(
         @PathVariable Long mandalartId,
         @Valid @RequestBody CoreGoalCreateRequest createRequest
@@ -63,7 +63,7 @@ public class CoreGoalController {
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_IDS_RETRIEVED_SUCCESS, response));
     }
 
-    @GetMapping("/mandalarts/{mandalartId}/core-goals")
+    @GetMapping("/onboarding/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<CoreGoalsResponse, Void>> getCoreGoals(
         @PathVariable Long mandalartId
     ) {
@@ -73,7 +73,7 @@ public class CoreGoalController {
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_LIST_RETRIEVED_SUCCESS, response));
     }
 
-    @PatchMapping("/core-goals/{coreGoalId}")
+    @PatchMapping("/onboarding/core-goals/{coreGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> updateCoreGoal(
         @PathVariable Long coreGoalId,
         @Valid @RequestBody CoreGoalUpdateRequest updateRequest
@@ -84,7 +84,7 @@ public class CoreGoalController {
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_ONBOARDING_UPDATED_SUCCESS));
     }
 
-    @DeleteMapping("/core-goals/{coreGoalId}")
+    @DeleteMapping("/onboarding/core-goals/{coreGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> deleteCoreGoal(
         @PathVariable Long coreGoalId
     ) {

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -73,7 +73,6 @@ public class SubGoalController {
         @Valid @RequestBody SubGoalUpdateRequest request
     ) {
         Long userId = 1L; // TODO: 로그인 구현되면 token에서 사용자id 가져오기
-
         subGoalCommandService.updateSubGoal(userId, subGoalId, request);
 
         return ResponseEntity.ok()
@@ -85,7 +84,6 @@ public class SubGoalController {
         @PathVariable Long subGoalId
     ) {
         Long userId = 1L; // TODO: 로그인 구현되면 token에서 사용자id 가져오기
-
         subGoalCommandService.deleteSubGoal(userId, subGoalId);
 
         return ResponseEntity.ok()

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
@@ -6,4 +6,5 @@ public class CoreGoalMessage {
     public static final String CORE_GOAL_IDS_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표 id들을 조회했습니다.";
     public static final String CORE_GOAL_LIST_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표를 조회하였습니다.";
     public static final String CORE_GOAL_ONBOARDING_UPDATED_SUCCESS = "성공적으로 해당 상위 목표의 내용을 수정하였습니다.";
+    public static final String CORE_GOAL_ONBOARDING_DELETED_SUCCESS = "성공적으로 해당 상위 목표를 삭제하였습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalRepository.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
 import java.util.List;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoal;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,5 @@ public interface SubGoalRepository extends JpaRepository<SubGoal, Long>, SubGoal
 
     boolean existsByCoreGoalIdAndPosition(Long coreGoalId, int position);
 
+    void deleteByCoreGoal(CoreGoal coreGoal);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepository.java
@@ -1,9 +1,12 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubGoalSnapshotRepository
     extends JpaRepository<SubGoalSnapshot, Long>, SubGoalSnapshotRepositoryCustom {
+
+    void deleteBySubGoal_CoreGoal(CoreGoal coreGoal);
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
@@ -19,6 +19,8 @@ import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalSnapshotRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
+import org.sopt36.ninedotserver.mandalart.repository.SubGoalRepository;
+import org.sopt36.ninedotserver.mandalart.repository.SubGoalSnapshotRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,8 @@ public class CoreGoalCommandService {
     private final MandalartRepository mandalartRepository;
     private final AiRecommendationService aiRecommendationService;
     private final CoreGoalSnapshotRepository coreGoalSnapshotRepository;
+    private final SubGoalRepository subGoalRepository;
+    private final SubGoalSnapshotRepository subGoalSnapshotRepository;
 
     @Transactional
     public CoreGoalCreateResponse createCoreGoal(
@@ -79,7 +83,12 @@ public class CoreGoalCommandService {
     public void deleteCoreGoal(Long userId, Long coreGoalSnapshotId) {
         CoreGoalSnapshot coreGoalSnapshot = getExistingCoreGoal(coreGoalSnapshotId);
         coreGoalSnapshot.verifyCoreGoalUser(userId);
+
         CoreGoal coreGoal = coreGoalSnapshot.getCoreGoal();
+
+        subGoalSnapshotRepository.deleteBySubGoal_CoreGoal(coreGoal);
+        subGoalRepository.deleteByCoreGoal(coreGoal);
+
         coreGoalSnapshotRepository.delete(coreGoalSnapshot);
         coreGoalRepository.delete(coreGoal);
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/CoreGoalCommandService.java
@@ -75,6 +75,15 @@ public class CoreGoalCommandService {
         coreGoalSnapshotRepository.save(coreGoalSnapshot);
     }
 
+    @Transactional
+    public void deleteCoreGoal(Long userId, Long coreGoalSnapshotId) {
+        CoreGoalSnapshot coreGoalSnapshot = getExistingCoreGoal(coreGoalSnapshotId);
+        coreGoalSnapshot.verifyCoreGoalUser(userId);
+        CoreGoal coreGoal = coreGoalSnapshot.getCoreGoal();
+        coreGoalSnapshotRepository.delete(coreGoalSnapshot);
+        coreGoalRepository.delete(coreGoal);
+    }
+
     private Mandalart getExistingMandalart(Long mandalartId) {
         return mandalartRepository.findById(mandalartId)
             .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -75,7 +75,9 @@ public class SubGoalCommandService {
     public void deleteSubGoal(Long userId, Long subGoalId) {
         SubGoalSnapshot subGoalSnapshot = getExistingSubGoal(subGoalId);
         subGoalSnapshot.verifySubGoalUser(userId);
+        SubGoal subGoal = subGoalSnapshot.getSubGoal();
         subGoalSnapshotRepository.delete(subGoalSnapshot);
+        subGoalRepository.delete(subGoal);
     }
 
     private void validateCreate(CoreGoalSnapshot coreGoalSnapshot, Long userId,


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #51

### ⭐️ 구현 내용
- [x] 온보딩 시 상위 목표 삭제 api 구현

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
화이팅팅팅 우리가 짱이야

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 핵심 목표(Core Goal)를 삭제할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 서브 목표(Sub Goal) 삭제 시, 연관된 모든 데이터가 올바르게 삭제되도록 개선되었습니다.

* **스타일**
  * 일부 불필요한 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->