### PR TITLE
[FEAT] #59: 하위 목표 완료 체크

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
@@ -1,10 +1,19 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_CREATED_SUCCESS;
+
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.HistoryCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.HistoryQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class HistoryController {
@@ -12,5 +21,18 @@ public class HistoryController {
     private final HistoryCommandService historyCommandService;
     private final HistoryQueryService historyQueryService;
 
+    @PostMapping("/sub-goals/{subGoalId}/histories")
+    public ResponseEntity<ApiResponse<Void, Void>> createHistory(
+        @PathVariable Long subGoalId
+    ) {
+        Long userId = 1L;
+
+        Long historyId = historyCommandService.createHistory(userId, subGoalId);
+        URI location = URI.create(
+            "/api/v1/sub-goals/" + subGoalId + "/histories/" + historyId);
+
+        return ResponseEntity.created(location)
+            .body(ApiResponse.created(HISTORY_CREATED_SUCCESS));
+    }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
@@ -2,4 +2,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 
 public class HistoryMessage {
 
+    public static final String HISTORY_CREATED_SUCCESS = "성공적으로 해당 하위 목표를 완료했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/HistoryErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/HistoryErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum HistoryErrorCode implements ErrorCode {
 
-    // TODO 에러 코드 별 메시지 관리. 추후 구현 시 아래 세미콜론 삭제
-    ;
+    // 409 Conflict
+    HISTORY_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 오늘 해당 하위 목표를 완료했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
@@ -1,5 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
+import java.time.LocalDate;
 import org.sopt36.ninedotserver.mandalart.domain.History;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface HistoryRepository extends JpaRepository<History, Long>, HistoryRepositoryCustom {
 
+    boolean existsBySubGoalSnapshotIdAndCompletedDate(Long subGoalSnapshotId, LocalDate now);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/HistoryCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/HistoryCommandService.java
@@ -1,12 +1,48 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
+import static org.sopt36.ninedotserver.mandalart.exception.HistoryErrorCode.HISTORY_ALREADY_COMPLETED;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_NOT_FOUND;
+
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.domain.History;
+import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+import org.sopt36.ninedotserver.mandalart.exception.HistoryException;
+import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.HistoryRepository;
+import org.sopt36.ninedotserver.mandalart.repository.SubGoalSnapshotRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class HistoryCommandService {
 
     private final HistoryRepository historyRepository;
+    private final SubGoalSnapshotRepository subGoalSnapshotRepository;
+
+    @Transactional
+    public Long createHistory(Long userId, Long subGoalSnapshotId) {
+        SubGoalSnapshot subGoalSnapshot = getValidSubGoalSnapshot(subGoalSnapshotId);
+        subGoalSnapshot.verifySubGoalUser(userId);
+        validateCanCompleteSubGoal(subGoalSnapshotId);
+
+        History history = History.create(subGoalSnapshot, LocalDate.now());
+        historyRepository.save(history);
+
+        return history.getId();
+    }
+
+    private SubGoalSnapshot getValidSubGoalSnapshot(Long subGoalSnapshotId) {
+        return subGoalSnapshotRepository.findById(subGoalSnapshotId)
+            .orElseThrow(() -> new SubGoalException(SUB_GOAL_NOT_FOUND));
+    }
+
+    private void validateCanCompleteSubGoal(Long subGoalSnapshotId) {
+        if (historyRepository
+            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshotId, LocalDate.now())
+        ) {
+            throw new HistoryException(HISTORY_ALREADY_COMPLETED);
+        }
+    }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #59

### ⭐️ 구현 내용
- [x] 하위 목표 완료 체크 api 구현

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
화이띵!!!!!!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 하위 목표 완료 기록을 생성하는 새로운 엔드포인트가 추가되었습니다.
  * 동일 하위 목표를 하루에 두 번 이상 완료할 수 없도록 중복 완료 시도 시 오류 메시지가 제공됩니다.

* **버그 수정**
  * 하위 목표 완료 시 사용자와 목표의 일치 여부가 검증됩니다.

* **알림**
  * 하위 목표 완료 성공 및 중복 완료 시의 안내 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->