### PR TITLE
[FEAT] #62: 하위 목표 완료 취소

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_CREATED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_DELETED_SUCCESS;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.HistoryCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.HistoryQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,16 @@ public class HistoryController {
 
         return ResponseEntity.created(location)
             .body(ApiResponse.created(HISTORY_CREATED_SUCCESS));
+    }
+
+    @DeleteMapping("/sub-goals/{subGoalId}/histories")
+    public ResponseEntity<ApiResponse<Void, Void>> deleteHistory(
+        @PathVariable Long subGoalId
+    ) {
+        Long userId = 1L;
+        historyCommandService.deleteHistory(userId, subGoalId);
+
+        return ResponseEntity.ok(ApiResponse.ok(HISTORY_DELETED_SUCCESS));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
@@ -3,4 +3,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 public class HistoryMessage {
 
     public static final String HISTORY_CREATED_SUCCESS = "성공적으로 해당 하위 목표를 완료했습니다.";
+    public static final String HISTORY_DELETED_SUCCESS = "성공적으로 해당 하위 목표 완료를 취소했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/HistoryErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/HistoryErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum HistoryErrorCode implements ErrorCode {
 
+    // 404 Not Found
+    HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "오늘 해당 하위 목표를 완료하지 않았습니다."),
+
     // 409 Conflict
     HISTORY_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 오늘 해당 하위 목표를 완료했습니다.");
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import org.sopt36.ninedotserver.mandalart.domain.History;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface HistoryRepository extends JpaRepository<History, Long>, HistoryRepositoryCustom {
 
     boolean existsBySubGoalSnapshotIdAndCompletedDate(Long subGoalSnapshotId, LocalDate now);
+
+    Optional<History> findBySubGoalSnapshotIdAndCompletedDate(Long subGoalSnapshotId,
+        LocalDate now);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/HistoryCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/HistoryCommandService.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
 import static org.sopt36.ninedotserver.mandalart.exception.HistoryErrorCode.HISTORY_ALREADY_COMPLETED;
+import static org.sopt36.ninedotserver.mandalart.exception.HistoryErrorCode.HISTORY_NOT_FOUND;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_NOT_FOUND;
 
 import java.time.LocalDate;
@@ -31,6 +32,18 @@ public class HistoryCommandService {
         historyRepository.save(history);
 
         return history.getId();
+    }
+
+    @Transactional
+    public void deleteHistory(Long userId, Long subGoalSnapshotId) {
+        SubGoalSnapshot subGoalSnapshot = getValidSubGoalSnapshot(subGoalSnapshotId);
+        subGoalSnapshot.verifySubGoalUser(userId);
+
+        History history = historyRepository
+            .findBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshotId, LocalDate.now())
+            .orElseThrow(() -> new HistoryException(HISTORY_NOT_FOUND));
+
+        historyRepository.delete(history);
     }
 
     private SubGoalSnapshot getValidSubGoalSnapshot(Long subGoalSnapshotId) {


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #62

### ⭐️ 구현 내용
- [x] 하위 목표 완료 취소

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
이제 3개 남았다~~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 하위 목표의 오늘 완료 기록을 취소(삭제)할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 오늘 완료하지 않은 하위 목표를 취소 시도할 경우, 적절한 안내 메시지와 함께 404 오류가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->