### PR TITLE
[FEAT] #74: 회원가입 시 직업 드롭다운 반환

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/CoreGoalRepositoryImpl.java
@@ -3,8 +3,12 @@ package org.sopt36.ninedotserver.mandalart.repository;
 import static org.sopt36.ninedotserver.mandalart.domain.QCoreGoal.coreGoal;
 import static org.sopt36.ninedotserver.mandalart.domain.QMandalart.mandalart;
 import static org.sopt36.ninedotserver.mandalart.domain.QSubGoal.subGoal;
+import static org.sopt36.ninedotserver.onboarding.domain.Domain.JOB;
+import static org.sopt36.ninedotserver.onboarding.domain.QChoice.choice;
+import static org.sopt36.ninedotserver.onboarding.domain.QQuestion.question;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/MandalartRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/MandalartRepositoryImpl.java
@@ -1,13 +1,10 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
-import static org.sopt36.ninedotserver.mandalart.domain.QCoreGoal.coreGoal;
 import static org.sopt36.ninedotserver.mandalart.domain.QMandalart.mandalart;
-import static org.sopt36.ninedotserver.mandalart.domain.QSubGoal.subGoal;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.sopt36.ninedotserver.mandalart.domain.QMandalart;
 import org.sopt36.ninedotserver.user.domain.User;
 
 @RequiredArgsConstructor
@@ -24,6 +21,7 @@ public class MandalartRepositoryImpl implements MandalartRepositoryCustom {
                             .fetchFirst();
         return found != null;
     }
+
     @Override
     public Optional<User> findUserById(Long mandalartId) {
         User result = queryFactory

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/controller/QuestionController.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/controller/QuestionController.java
@@ -1,9 +1,11 @@
 package org.sopt36.ninedotserver.onboarding.controller;
 
+import static org.sopt36.ninedotserver.onboarding.controller.message.QuestionMessage.JOB_DROPDOWN_RETRIEVED_SUCCESS;
 import static org.sopt36.ninedotserver.onboarding.controller.message.QuestionMessage.PERSONA_QUESTION_RETRIEVED_SUCCESS;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.onboarding.dto.response.JobDropdownResponse;
 import org.sopt36.ninedotserver.onboarding.dto.response.PersonaQuestionResponse;
 import org.sopt36.ninedotserver.onboarding.service.query.QuestionQueryService;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +24,11 @@ public class QuestionController {
     public ResponseEntity<ApiResponse<PersonaQuestionResponse, Void>> getPersonaQuestions() {
         PersonaQuestionResponse response = questionQueryService.getAllActivatedQuestions();
         return ResponseEntity.ok(ApiResponse.ok(PERSONA_QUESTION_RETRIEVED_SUCCESS, response));
+    }
+
+    @GetMapping("/jobs")
+    public ResponseEntity<ApiResponse<JobDropdownResponse, Void>> getJobDropdown() {
+        JobDropdownResponse response = questionQueryService.getJobDropdown();
+        return ResponseEntity.ok(ApiResponse.ok(JOB_DROPDOWN_RETRIEVED_SUCCESS, response));
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/controller/message/QuestionMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/controller/message/QuestionMessage.java
@@ -3,4 +3,5 @@ package org.sopt36.ninedotserver.onboarding.controller.message;
 public class QuestionMessage {
 
     public final static String PERSONA_QUESTION_RETRIEVED_SUCCESS = "페르소나 질문이 성공적으로 요청되었습니다.";
+    public final static String JOB_DROPDOWN_RETRIEVED_SUCCESS = "직업 드롭다운이 성공적으로 요청되었습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/dto/response/JobDropdownResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/dto/response/JobDropdownResponse.java
@@ -1,0 +1,20 @@
+package org.sopt36.ninedotserver.onboarding.dto.response;
+
+import java.util.List;
+import org.sopt36.ninedotserver.onboarding.domain.Choice;
+
+public record JobDropdownResponse(
+    List<Job> jobList
+) {
+
+    public static JobDropdownResponse of(List<Job> jobList) {
+        return new JobDropdownResponse(jobList);
+    }
+
+    public record Job(Long id, String job) {
+
+        public static Job from(Choice choice) {
+            return new Job(choice.getId(), choice.getContent());
+        }
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/exception/QuestionErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/exception/QuestionErrorCode.java
@@ -12,7 +12,8 @@ public enum QuestionErrorCode implements ErrorCode {
     INVALID_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "질문 내용은 255자까지 가능합니다."),
 
     // 404 NOT FOUND
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문 데이터가 존재하지 않습니다.");
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문 데이터가 존재하지 않습니다."),
+    JOB_DROPDOWN_NOT_FOUND(HttpStatus.NOT_FOUND, "직업 목록이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/repository/ChoiceRepositoryCustom.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/repository/ChoiceRepositoryCustom.java
@@ -1,5 +1,9 @@
 package org.sopt36.ninedotserver.onboarding.repository;
 
+import java.util.List;
+import org.sopt36.ninedotserver.onboarding.domain.Choice;
+
 public interface ChoiceRepositoryCustom {
 
+    List<Choice> findJobList();
 }

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/repository/ChoiceRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/repository/ChoiceRepositoryImpl.java
@@ -1,11 +1,26 @@
 package org.sopt36.ninedotserver.onboarding.repository;
 
+import static org.sopt36.ninedotserver.onboarding.domain.Domain.JOB;
+import static org.sopt36.ninedotserver.onboarding.domain.QChoice.choice;
+import static org.sopt36.ninedotserver.onboarding.domain.QQuestion.question;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.onboarding.domain.Choice;
 
 @RequiredArgsConstructor
 public class ChoiceRepositoryImpl implements ChoiceRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Choice> findJobList() {
+        return queryFactory
+                   .select(choice)
+                   .from(choice).join(choice.question, question)
+                   .where(question.domain.eq(JOB), choice.activated.isTrue())
+                   .fetch();
+    }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/onboarding/service/query/QuestionQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/onboarding/service/query/QuestionQueryService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.onboarding.domain.Choice;
 import org.sopt36.ninedotserver.onboarding.domain.Domain;
 import org.sopt36.ninedotserver.onboarding.domain.Question;
+import org.sopt36.ninedotserver.onboarding.dto.response.JobDropdownResponse;
+import org.sopt36.ninedotserver.onboarding.dto.response.JobDropdownResponse.Job;
 import org.sopt36.ninedotserver.onboarding.dto.response.PersonaQuestionResponse;
 import org.sopt36.ninedotserver.onboarding.dto.response.QuestionResponse;
 import org.sopt36.ninedotserver.onboarding.exception.QuestionErrorCode;
@@ -25,7 +27,8 @@ public class QuestionQueryService {
     private final ChoiceRepository choiceRepository;
 
     public PersonaQuestionResponse getAllActivatedQuestions() {
-        List<Question> questions = questionRepository.findAllByActivatedTrueAndDomain(Domain.PERSONA);
+        List<Question> questions = questionRepository.findAllByActivatedTrueAndDomain(
+            Domain.PERSONA);
         List<Choice> choices = choiceRepository.findAllByActivatedTrue();
 
         if (questions.isEmpty()) {
@@ -33,12 +36,25 @@ public class QuestionQueryService {
         }
 
         Map<Long, List<Choice>> choiceMap = choices.stream()
-            .collect(Collectors.groupingBy(c -> c.getQuestion().getId()));
+                                                .collect(Collectors.groupingBy(
+                                                    c -> c.getQuestion().getId()));
 
         List<QuestionResponse> responseList = questions.stream()
-            .map(q -> QuestionResponse.from(q, choiceMap.getOrDefault(q.getId(), List.of())))
-            .toList();
+                                                  .map(q -> QuestionResponse.from(q,
+                                                      choiceMap.getOrDefault(q.getId(), List.of())))
+                                                  .toList();
 
         return PersonaQuestionResponse.from(responseList);
+    }
+
+    public JobDropdownResponse getJobDropdown() {
+        List<Choice> jobChoiceList = choiceRepository.findJobList();
+        if (jobChoiceList.isEmpty()) {
+            throw new QuestionException(QuestionErrorCode.JOB_DROPDOWN_NOT_FOUND);
+        }
+        List<Job> jobList = jobChoiceList.stream()
+                                .map(JobDropdownResponse.Job::from)
+                                .toList();
+        return JobDropdownResponse.of(jobList);
     }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #74 

### ⭐️ 구현 내용
- [x] 직업 드롭다운 반환하긩

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 온보딩 과정에서 사용할 수 있는 직업 드롭다운 조회 API가 추가되었습니다.
  * 직업 드롭다운 데이터가 없을 경우를 위한 새로운 에러 코드와 메시지가 도입되었습니다.

* **버그 수정 및 개선**
  * 불필요한 import 및 공백이 정리되어 코드가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->