### PR TITLE
[FEAT] #72: 스트릭 트래커 반환

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -1,8 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.AI_RESPONSE_SUCCESS;
-import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CREATED_SUCCESS;
-import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.IDS_RETRIEVED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_AI_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.CoreGoalMessage.CORE_GOAL_IDS_RETRIEVED_SUCCESS;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
@@ -2,10 +2,12 @@ package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_DELETED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.HistoryMessage.HISTORY_RETRIEVED_SUCCESS;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.StreakListResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.HistoryCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.HistoryQueryService;
 import org.springframework.http.ResponseEntity;
@@ -49,12 +51,13 @@ public class HistoryController {
     }
 
     @GetMapping("/mandalarts/{mandalartId}/streaks")
-    public ResponseEntity<ApiResponse<Void, Void>> getStreaks(
+    public ResponseEntity<ApiResponse<StreakListResponse, Void>> getStreaks(
         @PathVariable Long mandalartId
     ) {
         Long userId = 1L;
+        StreakListResponse response = historyQueryService.getStreaks(userId, mandalartId);
 
-        return null;
+        return ResponseEntity.ok(ApiResponse.ok(HISTORY_RETRIEVED_SUCCESS, response));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/CoreGoalMessage.java
@@ -2,8 +2,6 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 
 public class CoreGoalMessage {
 
-    public static final String CREATED_SUCCESS = "성공적으로 해당 만다라트에 상위 목표를 추가했습니다.";
-    public static final String IDS_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표 id들을 조회했습니다.";
     public static final String AI_RESPONSE_SUCCESS = "AI를 성공적으로 호출하였습니다.";
     public static final String CORE_GOAL_CREATED_SUCCESS = "성공적으로 해당 만다라트에 상위 목표를 추가했습니다.";
     public static final String CORE_GOAL_IDS_RETRIEVED_SUCCESS = "성공적으로 해당 만다라트의 상위 목표 id들을 조회했습니다.";

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/HistoryMessage.java
@@ -4,4 +4,5 @@ public class HistoryMessage {
 
     public static final String HISTORY_CREATED_SUCCESS = "성공적으로 해당 하위 목표를 완료했습니다.";
     public static final String HISTORY_DELETED_SUCCESS = "성공적으로 해당 하위 목표 완료를 취소했습니다.";
+    public static final String HISTORY_RETRIEVED_SUCCESS = "성공적으로 스트릭 트래커 정보를 반환했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/StreakListResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/StreakListResponse.java
@@ -1,0 +1,12 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+
+public record StreakListResponse(
+    List<StreakResponse> streaks
+) {
+
+    public static StreakListResponse of(List<StreakResponse> streaks) {
+        return new StreakListResponse(List.copyOf(streaks));
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/StreakResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/StreakResponse.java
@@ -1,0 +1,11 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+
+public record StreakResponse(
+    int streakDay,
+    int completedTodoCount,
+    List<TodoResponse> completedTodos
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/TodoResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/TodoResponse.java
@@ -1,0 +1,8 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+public record TodoResponse(
+    Long id,
+    String title
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/HistoryRepository.java
@@ -1,6 +1,8 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.sopt36.ninedotserver.mandalart.domain.History;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,11 @@ public interface HistoryRepository extends JpaRepository<History, Long>, History
 
     Optional<History> findBySubGoalSnapshotIdAndCompletedDate(Long subGoalSnapshotId,
         LocalDate now);
+
+    List<History> findBySubGoalSnapshot_SubGoal_CoreGoal_Mandalart_IdAndCompletedDateBetween(
+        Long mandalartId,
+        LocalDate start,
+        LocalDate end
+    );
+
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/HistoryQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/HistoryQueryService.java
@@ -1,6 +1,20 @@
 package org.sopt36.ninedotserver.mandalart.service.query;
 
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.domain.History;
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+import org.sopt36.ninedotserver.mandalart.dto.response.StreakListResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.StreakResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.TodoResponse;
+import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.repository.HistoryRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
 import org.springframework.stereotype.Service;
@@ -13,5 +27,58 @@ public class HistoryQueryService {
 
     private final HistoryRepository historyRepository;
     private final MandalartRepository mandalartRepository;
-    
+
+    public StreakListResponse getStreaks(Long userId, Long mandalartId) {
+        Mandalart mandalart = getExistingMandalart(mandalartId);
+        mandalart.ensureOwnedBy(userId);
+
+        // 기간 계산
+        LocalDate startDate = mandalart.getCreatedAt().toLocalDate();
+        LocalDate today = LocalDate.now();
+        long totalDays = ChronoUnit.DAYS.between(startDate, today) + 1;
+
+        List<LocalDate> allDates = IntStream.range(0, (int) totalDays)
+            .mapToObj(startDate::plusDays)
+            .toList();
+
+        // 전체 히스토리 조회
+        List<History> allHistories = historyRepository
+            .findBySubGoalSnapshot_SubGoal_CoreGoal_Mandalart_IdAndCompletedDateBetween(
+                mandalartId,
+                startDate,
+                today
+            );
+
+        // 기간 전체 히스토리 조회 -> 날짜별 그룹핑
+        Map<LocalDate, List<TodoResponse>> grouped = allHistories.stream()
+            .collect(Collectors.groupingBy(
+                History::getCompletedDate,
+                Collectors.mapping(h -> new TodoResponse(
+                    h.getSubGoalSnapshot().getId(),
+                    h.getSubGoalSnapshot().getTitle()
+                ), Collectors.toList())
+            ));
+
+        // 스트릭 리스트 생성
+        List<StreakResponse> entries = allDates.stream()
+            .map(date -> {
+                List<TodoResponse> todos = grouped.getOrDefault(date, List.of());
+                int streakDay = (int) ChronoUnit.DAYS.between(startDate, date) + 1;
+                return new StreakResponse(
+                    streakDay,
+                    todos.size(),
+                    todos
+                );
+            })
+            .toList();
+
+        return StreakListResponse.of(entries);
+    }
+
+    private Mandalart getExistingMandalart(Long mandalartId) {
+        return mandalartRepository.findById(mandalartId)
+            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+    }
+
+
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #72

### ⭐️ 구현 내용
- [x] 스트릭 트래커 반환하기

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
이거 공부 좀 더 해야댐........

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 만다라트의 스트릭(연속 달성 기록) 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 스트릭 정보에는 각 날짜별로 완료한 할 일 목록과 완료 개수가 포함됩니다.

* **버그 수정**
  * 중복된 메시지 상수가 제거되어 메시지 관리가 더 명확해졌습니다.

* **기타**
  * 스트릭 및 할 일 정보를 위한 응답 구조가 새롭게 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->