### PR TITLE
[FEAT] #91: 만다라트 보드 전체 조회

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
 import static org.sopt36.ninedotserver.mandalart.controller.message.MandalartMessage.CREATED_SUCCESS;
+import static org.sopt36.ninedotserver.mandalart.controller.message.MandalartMessage.MANDALART_BOARD_RETRIEVED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.MandalartMessage.MANDALART_RETRIEVED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.MandalartMessage.PROGRESS_HISTORY_RETRIEVED_SUCCESS;
 
@@ -9,6 +10,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.request.MandalartCreateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.MandalartBoardResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.MandalartCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.MandalartHistoryResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.MandalartResponse;
@@ -43,7 +45,7 @@ public class MandalartController {
         URI location = URI.create("/api/v1/mandalarts/" + mandalartId);
 
         return ResponseEntity.created(location)
-                   .body(ApiResponse.created(response, CREATED_SUCCESS));
+            .body(ApiResponse.created(response, CREATED_SUCCESS));
     }
 
     @GetMapping("/mandalarts/{mandalartId}/histories")
@@ -65,5 +67,16 @@ public class MandalartController {
         Long userId = 1L;
         MandalartResponse response = mandalartQueryService.getMandalart(userId, mandalartId);
         return ResponseEntity.ok(ApiResponse.ok(MANDALART_RETRIEVED_SUCCESS, response));
+    }
+
+    @GetMapping("/mandalarts/{mandalartId}/board")
+    public ResponseEntity<ApiResponse<MandalartBoardResponse, Void>> getMandalartBoard(
+        @PathVariable Long mandalartId
+    ) {
+        Long userId = 1L;
+        MandalartBoardResponse response = mandalartQueryService
+            .getMandalartBoard(userId, mandalartId);
+
+        return ResponseEntity.ok(ApiResponse.ok(MANDALART_BOARD_RETRIEVED_SUCCESS, response));
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/MandalartMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/MandalartMessage.java
@@ -5,4 +5,5 @@ public class MandalartMessage {
     public static final String CREATED_SUCCESS = "만다라트가 등록되었습니다.";
     public static final String PROGRESS_HISTORY_RETRIEVED_SUCCESS = "성공적으로 만다라트 목표와 목표 시작 후 경과일을 조회했습니다.";
     public static final String MANDALART_RETRIEVED_SUCCESS = "만다라트 대목표를 성공적으로 조회했습니다.";
+    public static final String MANDALART_BOARD_RETRIEVED_SUCCESS = "성공적으로 만다라트를 조회하였습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalBoardResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/CoreGoalBoardResponse.java
@@ -1,0 +1,24 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoalSnapshot;
+
+public record CoreGoalBoardResponse(
+    Long id,
+    String title,
+    int position,
+    List<SubGoalBoardResponse> subGoals
+) {
+
+    public static CoreGoalBoardResponse of(
+        CoreGoalSnapshot coreGoalSnapshot,
+        List<SubGoalBoardResponse> subGoals
+    ) {
+        return new CoreGoalBoardResponse(
+            coreGoalSnapshot.getId(),
+            coreGoalSnapshot.getTitle(),
+            coreGoalSnapshot.getCoreGoal().getPosition(),
+            List.copyOf(subGoals)
+        );
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/MandalartBoardResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/MandalartBoardResponse.java
@@ -1,0 +1,17 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+
+public record MandalartBoardResponse(
+    String title,
+    List<CoreGoalBoardResponse> coreGoals
+) {
+
+    public static MandalartBoardResponse of(
+        Mandalart mandalart,
+        List<CoreGoalBoardResponse> coreGoals
+    ) {
+        return new MandalartBoardResponse(mandalart.getTitle(), List.copyOf(coreGoals));
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalBoardResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalBoardResponse.java
@@ -1,0 +1,18 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+
+public record SubGoalBoardResponse(
+    Long id,
+    String title,
+    int position
+) {
+
+    public static SubGoalBoardResponse from(SubGoalSnapshot subGoalSnapshot) {
+        return new SubGoalBoardResponse(
+            subGoalSnapshot.getId(),
+            subGoalSnapshot.getTitle(),
+            subGoalSnapshot.getSubGoal().getPosition()
+        );
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
@@ -19,4 +19,9 @@ public interface SubGoalSnapshotRepositoryCustom {
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoal(Long mandalartId,
         Long coreGoalSnapshotId, Cycle cycle);
+
+    List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
+        Long mandalartId,
+        Long coreGoalSnapshotId
+    );
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
@@ -103,4 +103,19 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
                 .and(subGoalSnapshot.validTo.isNull()))
             .fetch();
     }
+
+    @Override
+    public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
+        Long mandalartId, Long coreGoalSnapshotId) {
+        return queryFactory
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+            .where(coreGoal.mandalart.id.eq(mandalartId)
+                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                .and(subGoalSnapshot.validTo.isNull()))
+            .orderBy(subGoal.position.asc())
+            .fetch();
+    }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/MandalartQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/MandalartQueryService.java
@@ -3,12 +3,22 @@ package org.sopt36.ninedotserver.mandalart.service.query;
 import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
 
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoalSnapshot;
 import org.sopt36.ninedotserver.mandalart.domain.Mandalart;
+import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalBoardResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.MandalartBoardResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.MandalartHistoryResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.MandalartResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalBoardResponse;
 import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
+import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
+import org.sopt36.ninedotserver.mandalart.repository.CoreGoalSnapshotRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
+import org.sopt36.ninedotserver.mandalart.repository.SubGoalRepository;
+import org.sopt36.ninedotserver.mandalart.repository.SubGoalSnapshotRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +28,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MandalartQueryService {
 
     private final MandalartRepository mandalartRepository;
+    private final CoreGoalRepository coreGoalRepository;
+    private final CoreGoalSnapshotRepository coreGoalSnapshotRepository;
+    private final SubGoalRepository subGoalRepository;
+    private final SubGoalSnapshotRepository subGoalSnapshotRepository;
 
     public MandalartHistoryResponse getMandalartHistory(Long userId, Long mandalartId) {
         Mandalart mandalart = getExistingMandalart(mandalartId);
@@ -32,8 +46,43 @@ public class MandalartQueryService {
         return MandalartResponse.of(mandalart);
     }
 
+    public MandalartBoardResponse getMandalartBoard(Long userId, Long mandalartId) {
+        Mandalart mandalart = getExistingMandalart(mandalartId);
+        mandalart.ensureOwnedBy(userId);
+
+        List<CoreGoalSnapshot> coreGoalSnapshots = coreGoalSnapshotRepository
+            .findByMandalartIdOrderByPosition(mandalartId);
+
+        List<CoreGoalBoardResponse> coreGoalBoardResponses = getAllCoreGoalsWithSubGoals(
+            mandalartId,
+            coreGoalSnapshots
+        );
+
+        return MandalartBoardResponse.of(mandalart, coreGoalBoardResponses);
+    }
+
     private Mandalart getExistingMandalart(Long mandalartId) {
         return mandalartRepository.findById(mandalartId)
-                   .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+    }
+
+    private List<CoreGoalBoardResponse> getAllCoreGoalsWithSubGoals(Long mandalartId,
+        List<CoreGoalSnapshot> coreGoalSnapshots) {
+        return coreGoalSnapshots.stream()
+            .map(coreGoalSnapshot -> {
+                List<SubGoalSnapshot> subGoalSnapshots =
+                    subGoalSnapshotRepository
+                        .findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
+                            mandalartId,
+                            coreGoalSnapshot.getId()
+                        );
+
+                List<SubGoalBoardResponse> subGoalBoardResponses = subGoalSnapshots.stream()
+                    .map(SubGoalBoardResponse::from)
+                    .toList();
+
+                return CoreGoalBoardResponse.of(coreGoalSnapshot, subGoalBoardResponses);
+            })
+            .toList();
     }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #91

### ⭐️ 구현 내용
- [x] 만다라트 전체 조회 (만다라트 뷰) api 구현 완료

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
와 이제 api 구현 다했다 고생했다!!!!!! 이제 리팩토링 하자잉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 만다라트 보드를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.  
  * 만다라트의 제목과 핵심 목표 및 하위 목표 목록을 한 번에 확인할 수 있습니다.

* **버그 수정**
  * 일부 반환값의 포맷이 개선되었습니다.

* **문서화**
  * 만다라트 보드 조회 성공 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->