### PR TITLE
[FEAT] #87: 하위목표 추천값 ai에 추가

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -1,5 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_AI_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_AI_RECOMMENDATION_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_CREATE_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessage.SUB_GOAL_DELETE_SUCCESS;
@@ -16,8 +17,10 @@ import org.sopt36.ninedotserver.ai.dto.response.SubGoalAiResponse;
 import org.sopt36.ninedotserver.ai.service.AiSubGoalRecommendationService;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.domain.Cycle;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalAiListCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalUpdateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalAiListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
@@ -106,10 +109,12 @@ public class SubGoalController {
         @RequestBody @Valid SubGoalAiRequest request
     ) {
         Long userId = 1L; // TODO: 로그인 구현되면 로직 추가
-        SubGoalAiResponse response = aiSubGoalService.fetchAiSubGoalRecommendation(userId, coreGoalId,
+        SubGoalAiResponse response = aiSubGoalService.fetchAiSubGoalRecommendation(userId,
+            coreGoalId,
             request);
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_AI_RECOMMENDATION_SUCCESS, response));
     }
+
     @GetMapping("/mandalarts/{mandalartId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getSubGoal(
         @PathVariable Long mandalartId,
@@ -120,6 +125,18 @@ public class SubGoalController {
         SubGoalListResponse response = subGoalQueryService.getSubGoalWithFilter(userId, mandalartId,
             coreGoalId, cycle);
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_READ_SUCCESS, response));
+    }
+
+    @PostMapping("/core-goals/{coreGoalId}/sub-goals/ai")
+    public ResponseEntity<ApiResponse<SubGoalAiListResponse, Void>> addAiSubGoals(
+        @PathVariable Long coreGoalId,
+        @Valid @RequestBody SubGoalAiListCreateRequest aiCreateRequest
+    ) {
+        Long userId = 1L;
+        SubGoalAiListResponse response = subGoalCommandService
+            .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
+
+        return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_AI_CREATED_SUCCESS, response));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/SubGoalMessage.java
@@ -8,4 +8,5 @@ public class SubGoalMessage {
     public static final String SUB_GOAL_UPDATE_SUCCESS = "성공적으로 해당 하위 목표의 내용을 수정했습니다.";
     public static final String SUB_GOAL_DELETE_SUCCESS = "성공적으로 해당 하위 목표의 내용을 삭제했습니다.";
     public static final String SUB_GOAL_AI_RECOMMENDATION_SUCCESS = "하위 목표 AI 추천이 완료되었습니다.";
+    public static final String SUB_GOAL_AI_CREATED_SUCCESS = "성공적으로 AI 추천 목표들을 만다라트의 하위 목표에 저장했습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Cycle.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/domain/Cycle.java
@@ -1,5 +1,8 @@
 package org.sopt36.ninedotserver.mandalart.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Cycle {
     DAILY("매일"),
     WEEKLY("매주"),
@@ -9,9 +12,5 @@ public enum Cycle {
 
     Cycle(String label) {
         this.label = label;
-    }
-
-    public String getLabel() {
-        return label;
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiCreateRequest.java
@@ -3,6 +3,7 @@ package org.sopt36.ninedotserver.mandalart.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.sopt36.ninedotserver.mandalart.domain.Cycle;
 
 public record SubGoalAiCreateRequest(
     @NotBlank(message = "title은 필수 항목입니다.")
@@ -10,7 +11,7 @@ public record SubGoalAiCreateRequest(
     String title,
 
     @NotNull(message = "cycle은 필수 입력값입니다.")
-    String cycle
+    Cycle cycle
 ) {
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiCreateRequest.java
@@ -1,0 +1,16 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record SubGoalAiCreateRequest(
+    @NotBlank(message = "title은 필수 항목입니다.")
+    @Size(max = 30, message = "title은 최대 30자까지 입력 가능합니다.")
+    String title,
+
+    @NotNull(message = "cycle은 필수 입력값입니다.")
+    String cycle
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiListCreateRequest.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/request/SubGoalAiListCreateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt36.ninedotserver.mandalart.dto.request;
+
+import java.util.List;
+
+public record SubGoalAiListCreateRequest(
+    List<SubGoalAiCreateRequest> goals
+) {
+
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalAiListResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalAiListResponse.java
@@ -1,0 +1,17 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+
+public record SubGoalAiListResponse(
+    List<SubGoalAiResponse> subGoals
+) {
+
+    public static SubGoalAiListResponse of(List<SubGoalSnapshot> subGoals) {
+        return new SubGoalAiListResponse(
+            subGoals.stream()
+                .map(SubGoalAiResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalAiResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalAiResponse.java
@@ -1,0 +1,20 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+
+public record SubGoalAiResponse(
+    Long id,
+    String title,
+    int position,
+    String cycle
+) {
+
+    public static SubGoalAiResponse from(SubGoalSnapshot subGoalSnapshot) {
+        return new SubGoalAiResponse(
+            subGoalSnapshot.getId(),
+            subGoalSnapshot.getTitle(),
+            subGoalSnapshot.getSubGoal().getPosition(),
+            subGoalSnapshot.getCycle().toString()
+        );
+    }
+}

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/exception/SubGoalErrorCode.java
@@ -20,7 +20,8 @@ public enum SubGoalErrorCode implements ErrorCode {
 
     // 409 Conflict
     SUB_GOAL_COMPLETED(HttpStatus.CONFLICT, "이미 해당 상위 목표의 하위 목표 8개를 모두 작성하였습니다."),
-    SUB_GOAL_CONFLICT(HttpStatus.CONFLICT, "이미 해당 위치에 하위 목표가 존재합니다.");
+    SUB_GOAL_CONFLICT(HttpStatus.CONFLICT, "이미 해당 위치에 하위 목표가 존재합니다."),
+    SUB_GOAL_LIMITED(HttpStatus.CONFLICT, "하위 목표는 최대 8개까지 저장할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
@@ -24,4 +24,8 @@ public interface SubGoalSnapshotRepositoryCustom {
         Long mandalartId,
         Long coreGoalSnapshotId
     );
+
+    int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId);
+
+    List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId);
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
@@ -5,7 +5,6 @@ import static org.sopt36.ninedotserver.mandalart.domain.QCoreGoalSnapshot.coreGo
 import static org.sopt36.ninedotserver.mandalart.domain.QSubGoal.subGoal;
 import static org.sopt36.ninedotserver.mandalart.domain.QSubGoalSnapshot.subGoalSnapshot;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -116,6 +115,35 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
                 .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
                 .and(subGoalSnapshot.validTo.isNull()))
             .orderBy(subGoal.position.asc())
+            .fetch();
+    }
+
+    @Override
+    public int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId) {
+        Long count = queryFactory
+            .select(subGoalSnapshot.count())
+            .from(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .where(
+                coreGoal.id.eq(coreGoalId)
+                    .and(subGoalSnapshot.validTo.isNull())
+            )
+            .fetchOne();
+
+        return Math.toIntExact(count != null ? count : 0L);
+    }
+
+    @Override
+    public List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId) {
+        return queryFactory
+            .select(subGoal.position)
+            .from(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+            .where(coreGoalSnapshot.id.eq(coreGoalId)
+                .and(subGoalSnapshot.validTo.isNull()))
             .fetch();
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
@@ -142,7 +142,7 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
             .join(subGoalSnapshot.subGoal, subGoal)
             .join(subGoal.coreGoal, coreGoal)
             .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-            .where(coreGoalSnapshot.id.eq(coreGoalId)
+            .where(coreGoal.id.eq(coreGoalId)
                 .and(subGoalSnapshot.validTo.isNull()))
             .fetch();
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -177,7 +177,7 @@ public class SubGoalCommandService {
             .mapToObj(i -> SubGoalSnapshot.create(
                 subGoals.get(i),
                 createRequest.goals().get(i).title(),
-                Cycle.valueOf(createRequest.goals().get(i).cycle()),
+                createRequest.goals().get(i).cycle(),
                 now,
                 null))
             .toList();

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/SubGoalCommandService.java
@@ -3,16 +3,23 @@ package org.sopt36.ninedotserver.mandalart.service.command;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_COMPLETED;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_CONFLICT;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_LIMITED;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_NOT_FOUND;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.ai.service.AiRecommendationService;
+import org.sopt36.ninedotserver.mandalart.domain.CoreGoal;
 import org.sopt36.ninedotserver.mandalart.domain.CoreGoalSnapshot;
+import org.sopt36.ninedotserver.mandalart.domain.Cycle;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoal;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
+import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalAiListCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.SubGoalUpdateRequest;
+import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalAiListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
@@ -80,14 +87,37 @@ public class SubGoalCommandService {
         subGoalRepository.delete(subGoal);
     }
 
+    @Transactional
+    public SubGoalAiListResponse createAiSubGoals(
+        Long userId,
+        Long coreGoalSnapshotId,
+        SubGoalAiListCreateRequest createRequest
+    ) {
+        CoreGoalSnapshot coreGoalSnapshot = getExistingCoreGoal(coreGoalSnapshotId);
+        coreGoalSnapshot.verifyCoreGoalUser(userId);
+        validateSubGoalCounts(coreGoalSnapshot.getCoreGoal().getId(), createRequest);
+
+        List<Integer> freePositions = findFreePositions(
+            coreGoalSnapshot.getCoreGoal().getId(),
+            createRequest.goals().size()
+        );
+        List<SubGoal> subGoals = buildSubGoals(coreGoalSnapshot.getCoreGoal(), freePositions);
+        List<SubGoalSnapshot> snapshots = buildSnapshots(subGoals, createRequest);
+
+        subGoalRepository.saveAll(subGoals);
+        subGoalSnapshotRepository.saveAll(snapshots);
+
+        return SubGoalAiListResponse.of(snapshots);
+    }
+
     private void validateCreate(CoreGoalSnapshot coreGoalSnapshot, Long userId,
         SubGoalCreateRequest request) {
         validateSubGoalLimitNotExceeded(coreGoalSnapshot.getId());
         validateAlreadyExists(coreGoalSnapshot.getId(), request.position());
     }
 
-    private CoreGoalSnapshot getExistingCoreGoal(Long coreGoalId) {
-        return coreGoalSnapshotRepository.findById(coreGoalId)
+    private CoreGoalSnapshot getExistingCoreGoal(Long coreGoalSnapshotId) {
+        return coreGoalSnapshotRepository.findById(coreGoalSnapshotId)
             .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
     }
 
@@ -103,10 +133,54 @@ public class SubGoalCommandService {
         }
     }
 
-    private SubGoalSnapshot getExistingSubGoal(Long subGoalSnapShotId) {
-        return subGoalSnapshotRepository.findById(subGoalSnapShotId)
+    private SubGoalSnapshot getExistingSubGoal(Long subGoalSnapshotId) {
+        return subGoalSnapshotRepository.findById(subGoalSnapshotId)
             .orElseThrow(() -> new SubGoalException(SUB_GOAL_NOT_FOUND));
     }
 
+    private void validateSubGoalCounts(
+        Long coreGoalId,
+        SubGoalAiListCreateRequest createRequest
+    ) {
+        int existingSubGoals = subGoalSnapshotRepository
+            .countActiveSubGoalSnapshotByCoreGoal(coreGoalId);
+        int requestSubGoals = createRequest.goals().size();
+        if (existingSubGoals + requestSubGoals > MAX_SUB_GOALS) {
+            throw new SubGoalException(SUB_GOAL_LIMITED);
+        }
+    }
+
+    private List<Integer> findFreePositions(Long coreGoalId, int requiredCount) {
+        List<Integer> occupied = subGoalSnapshotRepository.findActiveSubGoalPositionsByCoreGoal(
+            coreGoalId);
+
+        return IntStream.rangeClosed(1, MAX_SUB_GOALS)
+            .filter(pos -> !occupied.contains(pos))
+            .limit(requiredCount)
+            .boxed()
+            .toList();
+    }
+
+    private List<SubGoal> buildSubGoals(CoreGoal coreGoal, List<Integer> positions) {
+        return positions.stream()
+            .map(position -> SubGoal.create(coreGoal, position))
+            .toList();
+    }
+
+    private List<SubGoalSnapshot> buildSnapshots(
+        List<SubGoal> subGoals,
+        SubGoalAiListCreateRequest createRequest
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return IntStream.range(0, subGoals.size())
+            .mapToObj(i -> SubGoalSnapshot.create(
+                subGoals.get(i),
+                createRequest.goals().get(i).title(),
+                Cycle.valueOf(createRequest.goals().get(i).cycle()),
+                now,
+                null))
+            .toList();
+    }
 
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #87

### ⭐️ 구현 내용
- [x] 하위목표 추천값 ai에 추가

--

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
찬민오빠한테 너무x100 미안

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * AI가 추천하는 하위 목표를 한 번에 여러 개 생성할 수 있는 엔드포인트가 추가되었습니다.
  * 하위 목표 생성 시 최대 8개까지 저장 가능하도록 제한 메시지가 추가되었습니다.

* **버그 수정**
  * 하위 목표 개수 제한 초과 시 적절한 안내 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->