### PR TITLE
[HOTFIX] #110: authentication 임시 삭제

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/CoreGoalController.java
@@ -17,8 +17,8 @@ import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalAiCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalCreateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.CoreGoalUpdateRequest;
-import org.sopt36.ninedotserver.mandalart.dto.request.MandalartUpdateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.request.GenerateCoreGoalRequest;
+import org.sopt36.ninedotserver.mandalart.dto.request.MandalartUpdateRequest;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalAiListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalCreateResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.CoreGoalIdsResponse;
@@ -28,7 +28,6 @@ import org.sopt36.ninedotserver.mandalart.service.query.CoreGoalQueryService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -67,11 +66,10 @@ public class CoreGoalController {
 
     @PostMapping("/onboarding/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<CoreGoalCreateResponse, Void>> createCoreGoal(
-        Authentication authentication,
         @PathVariable Long mandalartId,
         @Valid @RequestBody CoreGoalCreateRequest createRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         CoreGoalCreateResponse response = coreGoalCommandService.createCoreGoal(userId,
             mandalartId,
             createRequest
@@ -81,15 +79,14 @@ public class CoreGoalController {
             "/api/v1/mandalarts/" + mandalartId + "/core-goals/" + coreGoalId);
 
         return ResponseEntity.created(location)
-                   .body(ApiResponse.created(response, CORE_GOAL_CREATED_SUCCESS));
+            .body(ApiResponse.created(response, CORE_GOAL_CREATED_SUCCESS));
     }
 
     @GetMapping("/mandalarts/{mandalartId}/core-goals/id-positions")
     public ResponseEntity<ApiResponse<CoreGoalIdsResponse, Void>> getCoreGoalIds(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         CoreGoalIdsResponse response = coreGoalQueryService.getCoreGoalIds(userId, mandalartId);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_IDS_RETRIEVED_SUCCESS, response));
@@ -97,10 +94,9 @@ public class CoreGoalController {
 
     @GetMapping("/onboarding/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<CoreGoalsResponse, Void>> getCoreGoals(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         CoreGoalsResponse response = coreGoalQueryService.getCoreGoals(userId, mandalartId);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_LIST_RETRIEVED_SUCCESS, response));
@@ -108,11 +104,10 @@ public class CoreGoalController {
 
     @PatchMapping("/onboarding/core-goals/{coreGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> updateCoreGoal(
-        Authentication authentication,
         @PathVariable Long coreGoalId,
         @Valid @RequestBody CoreGoalUpdateRequest updateRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         coreGoalCommandService.updateCoreGoal(userId, coreGoalId, updateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_ONBOARDING_UPDATED_SUCCESS));
@@ -120,10 +115,9 @@ public class CoreGoalController {
 
     @DeleteMapping("/onboarding/core-goals/{coreGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> deleteCoreGoal(
-        Authentication authentication,
         @PathVariable Long coreGoalId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         coreGoalCommandService.deleteCoreGoal(userId, coreGoalId);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_ONBOARDING_DELETED_SUCCESS));
@@ -131,11 +125,10 @@ public class CoreGoalController {
 
     @PostMapping("/mandalarts/{mandalartId}/core-goals/ai")
     public ResponseEntity<ApiResponse<CoreGoalAiListResponse, Void>> createAiCoreGoals(
-        Authentication authentication,
         @PathVariable Long mandalartId,
         @Valid @RequestBody CoreGoalAiCreateRequest aiCreateRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         CoreGoalAiListResponse response = coreGoalCommandService.createAiCoreGoals(
             userId,
             mandalartId,
@@ -147,10 +140,9 @@ public class CoreGoalController {
 
     @PostMapping("/mandalarts/{mandalartId}/ai")
     public ResponseEntity<ApiResponse<CoreGoalAiResponse, Void>> createAI(
-        Authentication authentication,
         @PathVariable Long mandalartId,
         @RequestBody GenerateCoreGoalRequest generateRequest) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         CoreGoalAiResponse response = aiRecommendationService.fetchAiRecommendation(mandalartId);
 
         return ResponseEntity.ok(ApiResponse.created(response, AI_RESPONSE_SUCCESS));
@@ -158,11 +150,10 @@ public class CoreGoalController {
 
     @PatchMapping("/mandalarts/{mandalartId}/core-goals")
     public ResponseEntity<ApiResponse<Void, Void>> updateMandalart(
-        Authentication authentication,
         @PathVariable Long mandalartId,
         @Valid @RequestBody MandalartUpdateRequest updateRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         coreGoalCommandService.updateMandalart(userId, mandalartId, updateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(CORE_GOAL_UPDATED_WITH_SUB_GOALS_SUCCESS));

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/HistoryController.java
@@ -11,7 +11,6 @@ import org.sopt36.ninedotserver.mandalart.dto.response.StreakListResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.HistoryCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.HistoryQueryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,10 +28,9 @@ public class HistoryController {
 
     @PostMapping("/sub-goals/{subGoalId}/histories")
     public ResponseEntity<ApiResponse<Void, Void>> createHistory(
-        Authentication authentication,
         @PathVariable Long subGoalId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         Long historyId = historyCommandService.createHistory(userId, subGoalId);
         URI location = URI.create(
             "/api/v1/sub-goals/" + subGoalId + "/histories/" + historyId);
@@ -43,10 +41,9 @@ public class HistoryController {
 
     @DeleteMapping("/sub-goals/{subGoalId}/histories")
     public ResponseEntity<ApiResponse<Void, Void>> deleteHistory(
-        Authentication authentication,
         @PathVariable Long subGoalId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         historyCommandService.deleteHistory(userId, subGoalId);
 
         return ResponseEntity.ok(ApiResponse.ok(HISTORY_DELETED_SUCCESS));
@@ -54,10 +51,9 @@ public class HistoryController {
 
     @GetMapping("/mandalarts/{mandalartId}/streaks")
     public ResponseEntity<ApiResponse<StreakListResponse, Void>> getStreaks(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         StreakListResponse response = historyQueryService.getStreaks(userId, mandalartId);
 
         return ResponseEntity.ok(ApiResponse.ok(HISTORY_RETRIEVED_SUCCESS, response));

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/MandalartController.java
@@ -17,7 +17,6 @@ import org.sopt36.ninedotserver.mandalart.dto.response.MandalartResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.MandalartCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.MandalartQueryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,10 +34,9 @@ public class MandalartController {
 
     @PostMapping("/mandalarts")
     public ResponseEntity<ApiResponse<MandalartCreateResponse, Void>> createMandalart(
-        Authentication authentication,
         @Valid @RequestBody MandalartCreateRequest createRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         MandalartCreateResponse response = mandalartCommandService.createMandalart(
             userId,
             createRequest
@@ -52,10 +50,9 @@ public class MandalartController {
 
     @GetMapping("/mandalarts/{mandalartId}/histories")
     public ResponseEntity<ApiResponse<MandalartHistoryResponse, Void>> getMandalartProgressHistory(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         MandalartHistoryResponse response = mandalartQueryService.getMandalartHistory(
             userId,
             mandalartId
@@ -66,10 +63,9 @@ public class MandalartController {
 
     @GetMapping("/mandalarts/{mandalartId}")
     public ResponseEntity<ApiResponse<MandalartResponse, Void>> getMandalart(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         MandalartResponse response = mandalartQueryService.getMandalart(userId, mandalartId);
 
         return ResponseEntity.ok(ApiResponse.ok(MANDALART_RETRIEVED_SUCCESS, response));
@@ -77,10 +73,9 @@ public class MandalartController {
 
     @GetMapping("/mandalarts/{mandalartId}/board")
     public ResponseEntity<ApiResponse<MandalartBoardResponse, Void>> getMandalartBoard(
-        Authentication authentication,
         @PathVariable Long mandalartId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         MandalartBoardResponse response = mandalartQueryService
             .getMandalartBoard(userId, mandalartId);
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
@@ -9,7 +9,6 @@ import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
 import org.sopt36.ninedotserver.mandalart.service.query.RecommendationQueryService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,17 +24,16 @@ public class RecommendationController {
 
     @GetMapping("/mandalarts/{mandalartId}/histories/recommendation")
     public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getRecommendations(
-        Authentication authentiction,
         @PathVariable Long mandalartId,
         @RequestParam(value = "date", required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        Long userId = Long.parseLong(authentiction.getName());
+        Long userId = 1L;
         LocalDate recommendationDate = (date != null ? date : LocalDate.now());
 
         SubGoalListResponse response = recommendationQueryService
-                                           .getRecommendations(userId, mandalartId,
-                                               recommendationDate);
+            .getRecommendations(userId, mandalartId,
+                recommendationDate);
 
         return ResponseEntity.ok(ApiResponse.ok(RECOMMENDATION_RETRIEVED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -28,7 +28,6 @@ import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.SubGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.SubGoalQueryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -50,26 +49,24 @@ public class SubGoalController {
 
     @GetMapping("/core-goals/{coreGoalId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalIdListResponse, Void>> getSubGoalIds(
-        Authentication authentication,
         @PathVariable Long coreGoalId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         List<SubGoalIdResponse> subGoalIds = subGoalQueryService.getSubGoalIds(userId, coreGoalId);
 
         return ResponseEntity.ok()
-                   .body(
-                       ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
-                           SubGoalIdListResponse.from(subGoalIds))
-                   );
+            .body(
+                ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
+                    SubGoalIdListResponse.from(subGoalIds))
+            );
     }
 
     @PostMapping("/core-goals/{coreGoalId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalCreateResponse, Void>> createSubGoal(
-        Authentication authentication,
         @PathVariable Long coreGoalId,
         @Valid @RequestBody SubGoalCreateRequest request
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         SubGoalCreateResponse response = subGoalCommandService.createSubGoal(
             userId,
             coreGoalId,
@@ -79,42 +76,39 @@ public class SubGoalController {
             "/api/v1/core-goals/" + coreGoalId + "/sub-goals/" + response.id());
 
         return ResponseEntity.created(location)
-                   .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
+            .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
     }
 
     @PatchMapping("/sub-goals/{subGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> updateSubGoal(
-        Authentication authentication,
         @PathVariable Long subGoalId,
         @Valid @RequestBody SubGoalUpdateRequest request
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         subGoalCommandService.updateSubGoal(userId, subGoalId, request);
 
         return ResponseEntity.ok()
-                   .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
+            .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/sub-goals/{subGoalId}")
     public ResponseEntity<ApiResponse<Void, Void>> deleteSubGoal(
-        Authentication authentication,
         @PathVariable Long subGoalId
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         subGoalCommandService.deleteSubGoal(userId, subGoalId);
 
         return ResponseEntity.ok()
-                   .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
+            .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
 
     }
 
     @PostMapping("/{coreGoalId}/sub-goals/ai")
     public ResponseEntity<ApiResponse<SubGoalAiResponse, Void>> generateSubGoalByAi(
-        Authentication authentication,
         @PathVariable("coreGoalId") Long coreGoalId,
         @RequestBody @Valid SubGoalAiRequest request
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         SubGoalAiResponse response = aiSubGoalService.fetchAiSubGoalRecommendation(userId,
             coreGoalId,
             request);
@@ -123,12 +117,11 @@ public class SubGoalController {
 
     @GetMapping("/mandalarts/{mandalartId}/sub-goals")
     public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getSubGoal(
-        Authentication authentication,
         @PathVariable Long mandalartId,
         @RequestParam(required = false) Long coreGoalId,
         @RequestParam(required = false) Cycle cycle
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         SubGoalListResponse response = subGoalQueryService.getSubGoalWithFilter(userId, mandalartId,
             coreGoalId, cycle);
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_READ_SUCCESS, response));
@@ -136,13 +129,12 @@ public class SubGoalController {
 
     @PostMapping("/core-goals/{coreGoalId}/sub-goals/ai")
     public ResponseEntity<ApiResponse<SubGoalAiListResponse, Void>> addAiSubGoals(
-        Authentication authentication,
         @PathVariable Long coreGoalId,
         @Valid @RequestBody SubGoalAiListCreateRequest aiCreateRequest
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = 1L;
         SubGoalAiListResponse response = subGoalCommandService
-                                             .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
+            .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_AI_CREATED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt36/ninedotserver/user/controller/UserController.java
+++ b/src/main/java/org/sopt36/ninedotserver/user/controller/UserController.java
@@ -7,7 +7,6 @@ import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.user.dto.response.UserInfoResponse;
 import org.sopt36.ninedotserver.user.service.query.UserQueryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,9 +19,8 @@ public class UserController {
     private final UserQueryService userQueryService;
 
     @GetMapping("/users/info")
-    public ResponseEntity<ApiResponse<UserInfoResponse, Void>> getUserInfo(
-        Authentication authentication) {
-        Long userId = Long.parseLong(authentication.getName());
+    public ResponseEntity<ApiResponse<UserInfoResponse, Void>> getUserInfo() {
+        Long userId = 1L;
         UserInfoResponse response = userQueryService.getUserInfo(userId);
         return ResponseEntity.ok(ApiResponse.ok(USER_INFO_RETRIEVED_SUCCESS, response));
     }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [ ] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [ ] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] Assignee 지정해 주세요.
- [ ] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #110

### ⭐️ 구현 내용
- [ ] 
- [ ] 

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 모든 컨트롤러의 엔드포인트에서 사용자 인증 관련 파라미터가 제거되었습니다.
  * 사용자 ID가 고정값(1L)으로 처리되어, 더 이상 로그인 정보에 따라 동작하지 않습니다.  
  * 기존 기능의 사용 방식에는 변화가 없으며, 엔드포인트 호출 시 인증 정보 입력이 필요하지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->