### PR TITLE
[HOTFIX] #135: 온보딩 시 맞춤 추천 하위 목표 저장

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
@@ -1,16 +1,19 @@
 package org.sopt36.ninedotserver.mandalart.controller;
 
+import static org.sopt36.ninedotserver.mandalart.controller.message.RecommendationMessage.RECOMMENDATION_CREATED_SUCCESS;
 import static org.sopt36.ninedotserver.mandalart.controller.message.RecommendationMessage.RECOMMENDATION_RETRIEVED_SUCCESS;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.global.dto.response.ApiResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
+import org.sopt36.ninedotserver.mandalart.service.command.RecommendationSchedulerService;
 import org.sopt36.ninedotserver.mandalart.service.query.RecommendationQueryService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecommendationController {
 
     private final RecommendationQueryService recommendationQueryService;
+    private final RecommendationSchedulerService schedulerService;
 
     @GetMapping("/mandalarts/{mandalartId}/histories/recommendation")
     public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getRecommendations(
@@ -36,6 +40,17 @@ public class RecommendationController {
                 recommendationDate);
 
         return ResponseEntity.ok(ApiResponse.ok(RECOMMENDATION_RETRIEVED_SUCCESS, response));
+    }
+
+
+    @PostMapping("/mandalarts/{mandalartId}/onboarding/recommendation")
+    public ResponseEntity<ApiResponse<Void, Void>> createRecommendation(
+        @PathVariable Long mandalartId
+    ) {
+        Long userId = 1L;
+        schedulerService.computeRecommendations(userId, mandalartId);
+
+        return ResponseEntity.ok(ApiResponse.ok(RECOMMENDATION_CREATED_SUCCESS));
     }
 
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/RecommendationMessage.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/message/RecommendationMessage.java
@@ -3,4 +3,5 @@ package org.sopt36.ninedotserver.mandalart.controller.message;
 public class RecommendationMessage {
 
     public static final String RECOMMENDATION_RETRIEVED_SUCCESS = "성공적으로 오늘의 맞춤 추천 할 일을 조회하였습니다.";
+    public static final String RECOMMENDATION_CREATED_SUCCESS = "성공적으로 맞춤 추천 하위 목표를 생성하였습니다.";
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/RecommendationSchedulerService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/command/RecommendationSchedulerService.java
@@ -1,12 +1,10 @@
 package org.sopt36.ninedotserver.mandalart.service.command;
 
-import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.SUB_GOAL_NOT_FOUND;
 import static org.sopt36.ninedotserver.user.exception.UserErrorCode.USER_NOT_FOUND;
 
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,8 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sopt36.ninedotserver.mandalart.domain.Recommendation;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
-import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalDetailResponse;
-import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.HistoryRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
 import org.sopt36.ninedotserver.mandalart.repository.RecommendationRepository;
@@ -39,11 +35,9 @@ public class RecommendationSchedulerService {
     private final MandalartRepository mandalartRepository;
     private final HistoryRepository historyRepository;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
     @Transactional
     public void generateDailyRecommendations() {
-        LocalDate today = LocalDate.now();
-
         userRepository.findAll().forEach(user -> {
             log.info("Executing generateDailyRecommendations()");
 
@@ -51,22 +45,13 @@ public class RecommendationSchedulerService {
             List<Long> mandalartIds = mandalartRepository.findIdByUserId(userId);
 
             for (Long mandalartId : mandalartIds) {
-                List<SubGoalDetailResponse> recs = computeRecommendations(userId, mandalartId);
-
-                recs.forEach(dto -> {
-                    SubGoalSnapshot snap =
-                        subGoalSnapshotRepository.findById(dto.id())
-                            .orElseThrow(() -> new SubGoalException(SUB_GOAL_NOT_FOUND));
-
-                    Recommendation rec = Recommendation.create(user, snap, today);
-                    recommendationRepository.save(rec);
-                });
+                computeRecommendations(userId, mandalartId);
             }
         });
     }
 
     @Transactional
-    public List<SubGoalDetailResponse> computeRecommendations(Long userId, Long mandalartId) {
+    public void computeRecommendations(Long userId, Long mandalartId) {
         LocalDate today = LocalDate.now();
 
         // 1) 가입일 기준으로 filterDays 계산
@@ -100,11 +85,9 @@ public class RecommendationSchedulerService {
             .toList();
 
         // 5) Recommendation에 저장 & DTO 변환
-        List<SubGoalDetailResponse> result = new ArrayList<>();
         for (SubGoalSnapshot snapshot : picked) {
-            result.add(SubGoalDetailResponse.from(snapshot));
+            Recommendation rec = Recommendation.create(user, snapshot, today);
+            recommendationRepository.save(rec);
         }
-
-        return result;
     }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #135

### ⭐️ 구현 내용
- [x] 온보딩 시 맞춤 추천 하위 목표 저장

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 만다라트에 대한 맞춤 추천 하위 목표를 생성하는 새로운 POST 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 맞춤 추천 생성 시 성공 메시지가 명확하게 안내됩니다.

* **기타 변경**
  * 맞춤 추천 생성 프로세스가 간소화되어 더욱 효율적으로 처리됩니다.
  * 추천 생성 스케줄 시간이 오전 2시로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->