### PR TITLE
[FIX] (#136/mandalart): sub goal position 순서대로 반환, 날짜별로 반환,완료여부도 반환

### DIFF
--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/RecommendationController.java
@@ -32,8 +32,7 @@ public class RecommendationController {
         LocalDate recommendationDate = (date != null ? date : LocalDate.now());
 
         SubGoalListResponse response = recommendationQueryService
-            .getRecommendations(userId, mandalartId,
-                recommendationDate);
+            .getRecommendations(userId, mandalartId, recommendationDate);
 
         return ResponseEntity.ok(ApiResponse.ok(RECOMMENDATION_RETRIEVED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -55,10 +55,10 @@ public class SubGoalController {
         List<SubGoalIdResponse> subGoalIds = subGoalQueryService.getSubGoalIds(userId, coreGoalId);
 
         return ResponseEntity.ok()
-            .body(
-                ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
-                    SubGoalIdListResponse.from(subGoalIds))
-            );
+                   .body(
+                       ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
+                           SubGoalIdListResponse.from(subGoalIds))
+                   );
     }
 
     @PostMapping("/core-goals/{coreGoalId}/sub-goals")
@@ -76,7 +76,7 @@ public class SubGoalController {
             "/api/v1/core-goals/" + coreGoalId + "/sub-goals/" + response.id());
 
         return ResponseEntity.created(location)
-            .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
+                   .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
     }
 
     @PatchMapping("/sub-goals/{subGoalId}")
@@ -88,7 +88,7 @@ public class SubGoalController {
         subGoalCommandService.updateSubGoal(userId, subGoalId, request);
 
         return ResponseEntity.ok()
-            .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
+                   .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/sub-goals/{subGoalId}")
@@ -99,7 +99,7 @@ public class SubGoalController {
         subGoalCommandService.deleteSubGoal(userId, subGoalId);
 
         return ResponseEntity.ok()
-            .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
+                   .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
 
     }
 
@@ -134,7 +134,7 @@ public class SubGoalController {
     ) {
         Long userId = 1L;
         SubGoalAiListResponse response = subGoalCommandService
-            .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
+                                             .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_AI_CREATED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/controller/SubGoalController.java
@@ -10,6 +10,7 @@ import static org.sopt36.ninedotserver.mandalart.controller.message.SubGoalMessa
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.ai.dto.request.SubGoalAiRequest;
@@ -27,6 +28,7 @@ import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
 import org.sopt36.ninedotserver.mandalart.service.command.SubGoalCommandService;
 import org.sopt36.ninedotserver.mandalart.service.query.SubGoalQueryService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,10 +57,10 @@ public class SubGoalController {
         List<SubGoalIdResponse> subGoalIds = subGoalQueryService.getSubGoalIds(userId, coreGoalId);
 
         return ResponseEntity.ok()
-                   .body(
-                       ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
-                           SubGoalIdListResponse.from(subGoalIds))
-                   );
+            .body(
+                ApiResponse.ok(SUB_GOAL_ID_LIST_FETCH_SUCCESS,
+                    SubGoalIdListResponse.from(subGoalIds))
+            );
     }
 
     @PostMapping("/core-goals/{coreGoalId}/sub-goals")
@@ -76,7 +78,7 @@ public class SubGoalController {
             "/api/v1/core-goals/" + coreGoalId + "/sub-goals/" + response.id());
 
         return ResponseEntity.created(location)
-                   .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
+            .body(ApiResponse.created(response, SUB_GOAL_CREATE_SUCCESS));
     }
 
     @PatchMapping("/sub-goals/{subGoalId}")
@@ -88,7 +90,7 @@ public class SubGoalController {
         subGoalCommandService.updateSubGoal(userId, subGoalId, request);
 
         return ResponseEntity.ok()
-                   .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
+            .body(ApiResponse.ok(SUB_GOAL_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/sub-goals/{subGoalId}")
@@ -99,7 +101,7 @@ public class SubGoalController {
         subGoalCommandService.deleteSubGoal(userId, subGoalId);
 
         return ResponseEntity.ok()
-                   .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
+            .body(ApiResponse.ok(SUB_GOAL_DELETE_SUCCESS));
 
     }
 
@@ -119,11 +121,12 @@ public class SubGoalController {
     public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getSubGoal(
         @PathVariable Long mandalartId,
         @RequestParam(required = false) Long coreGoalId,
-        @RequestParam(required = false) Cycle cycle
+        @RequestParam(required = false) Cycle cycle,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         Long userId = 1L;
         SubGoalListResponse response = subGoalQueryService.getSubGoalWithFilter(userId, mandalartId,
-            coreGoalId, cycle);
+            coreGoalId, cycle, date);
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_READ_SUCCESS, response));
     }
 
@@ -134,7 +137,7 @@ public class SubGoalController {
     ) {
         Long userId = 1L;
         SubGoalAiListResponse response = subGoalCommandService
-                                             .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
+            .createAiSubGoals(userId, coreGoalId, aiCreateRequest);
 
         return ResponseEntity.ok(ApiResponse.ok(SUB_GOAL_AI_CREATED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalDetailResponse.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalDetailResponse.java
@@ -5,14 +5,16 @@ import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
 public record SubGoalDetailResponse(
     Long id,
     String title,
-    String cycle
+    String cycle,
+    boolean isCompleted
 ) {
 
-    public static SubGoalDetailResponse from(SubGoalSnapshot subGoalSnapshot) {
+    public static SubGoalDetailResponse of(SubGoalSnapshot subGoalSnapshot, boolean isCompleted) {
         return new SubGoalDetailResponse(
             subGoalSnapshot.getId(),
             subGoalSnapshot.getTitle(),
-            subGoalSnapshot.getCycle().toString()
+            subGoalSnapshot.getCycle().toString(),
+            isCompleted
         );
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
@@ -10,20 +10,19 @@ public interface SubGoalSnapshotRepositoryCustom {
 
     List<SubGoalSnapshot> findAllByMandalartId(Long mandalartId);
 
-    List<SubGoalSnapshot> findAllActiveSubGoalSnapshot(Long mandalartId);
+    List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId);
 
-    List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycle(Long mandalartId, Cycle cycle);
-
-    List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoal(Long mandalartId,
-        Long coreGoalSnapshotId);
-
-    List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoal(Long mandalartId,
-        Long coreGoalSnapshotId, Cycle cycle);
+    List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycleOrderByPosition(Long mandalartId,
+        Cycle cycle);
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
         Long mandalartId,
-        Long coreGoalSnapshotId
-    );
+        Long coreGoalSnapshotId);
+
+    List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
+        Long mandalartId,
+        Long coreGoalSnapshotId, Cycle cycle);
+
 
     int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId);
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryCustom.java
@@ -1,5 +1,6 @@
 package org.sopt36.ninedotserver.mandalart.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.sopt36.ninedotserver.mandalart.domain.Cycle;
 import org.sopt36.ninedotserver.mandalart.domain.SubGoalSnapshot;
@@ -10,7 +11,8 @@ public interface SubGoalSnapshotRepositoryCustom {
 
     List<SubGoalSnapshot> findAllByMandalartId(Long mandalartId);
 
-    List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId);
+    List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId,
+        LocalDate date);
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycleOrderByPosition(Long mandalartId,
         Cycle cycle);

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
@@ -6,6 +6,7 @@ import static org.sopt36.ninedotserver.mandalart.domain.QSubGoal.subGoal;
 import static org.sopt36.ninedotserver.mandalart.domain.QSubGoalSnapshot.subGoalSnapshot;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.mandalart.domain.Cycle;
@@ -26,16 +27,16 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
         QCoreGoal coreGoal = QCoreGoal.coreGoal;
 
         return queryFactory
-                   .selectFrom(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal).fetchJoin()
-                   .join(subGoal.coreGoal, coreGoal).fetchJoin()
-                   .where(coreGoal.id.eq(
-                       queryFactory.select(coreGoalSnapshot.coreGoal.id)
-                           .from(coreGoalSnapshot)
-                           .where(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                   ))
-                   .orderBy(subGoalSnapshot.subGoal.position.asc())
-                   .fetch();
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal).fetchJoin()
+            .join(subGoal.coreGoal, coreGoal).fetchJoin()
+            .where(coreGoal.id.eq(
+                queryFactory.select(coreGoalSnapshot.coreGoal.id)
+                    .from(coreGoalSnapshot)
+                    .where(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+            ))
+            .orderBy(subGoalSnapshot.subGoal.position.asc())
+            .fetch();
     }
 
     @Override
@@ -45,37 +46,40 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
         QCoreGoal cg = coreGoal;
 
         return queryFactory
-                   .selectFrom(s)
-                   .join(s.subGoal, sg)
-                   .join(sg.coreGoal, cg)
-                   .where(cg.mandalart.id.eq(mandalartId))
-                   .fetch();
+            .selectFrom(s)
+            .join(s.subGoal, sg)
+            .join(sg.coreGoal, cg)
+            .where(cg.mandalart.id.eq(mandalartId))
+            .fetch();
     }
 
     @Override
-    public List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId) {
+    public List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId,
+        LocalDate date) {
+        //date가 valid from이랑 valid to 사이인 애들은 다 갖고와.
+        //그리고 history에서 completed date가 date랑 일치된 애들은 다 체크표시해서 반환해
         return queryFactory
-                   .selectFrom(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal)
-                   .join(subGoal.coreGoal, coreGoal)
-                   .where(coreGoal.mandalart.id.eq(mandalartId)
-                              .and(subGoalSnapshot.validTo.isNull()))
-                   .orderBy(coreGoal.position.asc(), subGoal.position.asc())
-                   .fetch();
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .where(coreGoal.mandalart.id.eq(mandalartId)
+                .and(subGoalSnapshot.validTo.isNull()))
+            .orderBy(coreGoal.position.asc(), subGoal.position.asc())
+            .fetch();
     }
 
     @Override
     public List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycleOrderByPosition(Long mandalartId,
         Cycle cycle) {
         return queryFactory
-                   .selectFrom(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal)
-                   .join(subGoal.coreGoal, coreGoal)
-                   .where(coreGoal.mandalart.id.eq(mandalartId)
-                              .and(subGoalSnapshot.validTo.isNull())
-                              .and(subGoalSnapshot.cycle.eq(cycle)))
-                   .orderBy(coreGoal.position.asc(), subGoal.position.asc())
-                   .fetch();
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .where(coreGoal.mandalart.id.eq(mandalartId)
+                .and(subGoalSnapshot.validTo.isNull())
+                .and(subGoalSnapshot.cycle.eq(cycle)))
+            .orderBy(coreGoal.position.asc(), subGoal.position.asc())
+            .fetch();
     }
 
     @Override
@@ -83,45 +87,45 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
         Long mandalartId,
         Long coreGoalSnapshotId) {
         return queryFactory
-                   .selectFrom(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal)
-                   .join(subGoal.coreGoal, coreGoal)
-                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-                   .where(coreGoal.mandalart.id.eq(mandalartId)
-                              .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                              .and(subGoalSnapshot.validTo.isNull()))
-                   .orderBy(subGoal.position.asc())
-                   .fetch();
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+            .where(coreGoal.mandalart.id.eq(mandalartId)
+                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                .and(subGoalSnapshot.validTo.isNull()))
+            .orderBy(subGoal.position.asc())
+            .fetch();
     }
 
     @Override
     public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
         Long mandalartId, Long coreGoalSnapshotId, Cycle cycle) {
         return queryFactory
-                   .selectFrom(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal)
-                   .join(subGoal.coreGoal, coreGoal)
-                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-                   .where(coreGoal.mandalart.id.eq(mandalartId)
-                              .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                              .and(subGoalSnapshot.cycle.eq(cycle))
-                              .and(subGoalSnapshot.validTo.isNull()))
-                   .orderBy(subGoal.position.asc())
-                   .fetch();
+            .selectFrom(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+            .where(coreGoal.mandalart.id.eq(mandalartId)
+                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                .and(subGoalSnapshot.cycle.eq(cycle))
+                .and(subGoalSnapshot.validTo.isNull()))
+            .orderBy(subGoal.position.asc())
+            .fetch();
     }
 
     @Override
     public int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId) {
         Long count = queryFactory
-                         .select(subGoalSnapshot.count())
-                         .from(subGoalSnapshot)
-                         .join(subGoalSnapshot.subGoal, subGoal)
-                         .join(subGoal.coreGoal, coreGoal)
-                         .where(
-                             coreGoal.id.eq(coreGoalId)
-                                 .and(subGoalSnapshot.validTo.isNull())
-                         )
-                         .fetchOne();
+            .select(subGoalSnapshot.count())
+            .from(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .where(
+                coreGoal.id.eq(coreGoalId)
+                    .and(subGoalSnapshot.validTo.isNull())
+            )
+            .fetchOne();
 
         return Math.toIntExact(count != null ? count : 0L);
     }
@@ -129,13 +133,13 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
     @Override
     public List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId) {
         return queryFactory
-                   .select(subGoal.position)
-                   .from(subGoalSnapshot)
-                   .join(subGoalSnapshot.subGoal, subGoal)
-                   .join(subGoal.coreGoal, coreGoal)
-                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-                   .where(coreGoal.id.eq(coreGoalId)
-                              .and(subGoalSnapshot.validTo.isNull()))
-                   .fetch();
+            .select(subGoal.position)
+            .from(subGoalSnapshot)
+            .join(subGoalSnapshot.subGoal, subGoal)
+            .join(subGoal.coreGoal, coreGoal)
+            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+            .where(coreGoal.id.eq(coreGoalId)
+                .and(subGoalSnapshot.validTo.isNull()))
+            .fetch();
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/repository/SubGoalSnapshotRepositoryImpl.java
@@ -26,16 +26,16 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
         QCoreGoal coreGoal = QCoreGoal.coreGoal;
 
         return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal).fetchJoin()
-            .join(subGoal.coreGoal, coreGoal).fetchJoin()
-            .where(coreGoal.id.eq(
-                queryFactory.select(coreGoalSnapshot.coreGoal.id)
-                    .from(coreGoalSnapshot)
-                    .where(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-            ))
-            .orderBy(subGoalSnapshot.subGoal.position.asc())
-            .fetch();
+                   .selectFrom(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal).fetchJoin()
+                   .join(subGoal.coreGoal, coreGoal).fetchJoin()
+                   .where(coreGoal.id.eq(
+                       queryFactory.select(coreGoalSnapshot.coreGoal.id)
+                           .from(coreGoalSnapshot)
+                           .where(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                   ))
+                   .orderBy(subGoalSnapshot.subGoal.position.asc())
+                   .fetch();
     }
 
     @Override
@@ -45,91 +45,83 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
         QCoreGoal cg = coreGoal;
 
         return queryFactory
-            .selectFrom(s)
-            .join(s.subGoal, sg)
-            .join(sg.coreGoal, cg)
-            .where(cg.mandalart.id.eq(mandalartId))
-            .fetch();
+                   .selectFrom(s)
+                   .join(s.subGoal, sg)
+                   .join(sg.coreGoal, cg)
+                   .where(cg.mandalart.id.eq(mandalartId))
+                   .fetch();
     }
 
     @Override
-    public List<SubGoalSnapshot> findAllActiveSubGoalSnapshot(Long mandalartId) {
+    public List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId) {
         return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .where(coreGoal.mandalart.id.eq(mandalartId).and(subGoalSnapshot.validTo.isNull()))
-            .fetch();
+                   .selectFrom(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal)
+                   .join(subGoal.coreGoal, coreGoal)
+                   .where(coreGoal.mandalart.id.eq(mandalartId)
+                              .and(subGoalSnapshot.validTo.isNull()))
+                   .orderBy(coreGoal.position.asc(), subGoal.position.asc())
+                   .fetch();
     }
 
     @Override
-    public List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycle(Long mandalartId, Cycle cycle) {
+    public List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycleOrderByPosition(Long mandalartId,
+        Cycle cycle) {
         return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .where(coreGoal.mandalart.id.eq(mandalartId)
-                .and(subGoalSnapshot.validTo.isNull())
-                .and(subGoalSnapshot.cycle.eq(cycle)))
-            .fetch();
-    }
-
-    @Override
-    public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoal(Long mandalartId,
-        Long coreGoalSnapshotId) {
-        return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-            .where(coreGoal.mandalart.id.eq(mandalartId)
-                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                .and(subGoalSnapshot.validTo.isNull()))
-            .fetch();
-    }
-
-    @Override
-    public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoal(
-        Long mandalartId, Long coreGoalSnapshotId, Cycle cycle) {
-        return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-            .where(coreGoal.mandalart.id.eq(mandalartId)
-                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                .and(subGoalSnapshot.cycle.eq(cycle))
-                .and(subGoalSnapshot.validTo.isNull()))
-            .fetch();
+                   .selectFrom(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal)
+                   .join(subGoal.coreGoal, coreGoal)
+                   .where(coreGoal.mandalart.id.eq(mandalartId)
+                              .and(subGoalSnapshot.validTo.isNull())
+                              .and(subGoalSnapshot.cycle.eq(cycle)))
+                   .orderBy(coreGoal.position.asc(), subGoal.position.asc())
+                   .fetch();
     }
 
     @Override
     public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
-        Long mandalartId, Long coreGoalSnapshotId) {
+        Long mandalartId,
+        Long coreGoalSnapshotId) {
         return queryFactory
-            .selectFrom(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-            .where(coreGoal.mandalart.id.eq(mandalartId)
-                .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
-                .and(subGoalSnapshot.validTo.isNull()))
-            .orderBy(subGoal.position.asc())
-            .fetch();
+                   .selectFrom(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal)
+                   .join(subGoal.coreGoal, coreGoal)
+                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+                   .where(coreGoal.mandalart.id.eq(mandalartId)
+                              .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                              .and(subGoalSnapshot.validTo.isNull()))
+                   .orderBy(subGoal.position.asc())
+                   .fetch();
+    }
+
+    @Override
+    public List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
+        Long mandalartId, Long coreGoalSnapshotId, Cycle cycle) {
+        return queryFactory
+                   .selectFrom(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal)
+                   .join(subGoal.coreGoal, coreGoal)
+                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+                   .where(coreGoal.mandalart.id.eq(mandalartId)
+                              .and(coreGoalSnapshot.id.eq(coreGoalSnapshotId))
+                              .and(subGoalSnapshot.cycle.eq(cycle))
+                              .and(subGoalSnapshot.validTo.isNull()))
+                   .orderBy(subGoal.position.asc())
+                   .fetch();
     }
 
     @Override
     public int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId) {
         Long count = queryFactory
-            .select(subGoalSnapshot.count())
-            .from(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .where(
-                coreGoal.id.eq(coreGoalId)
-                    .and(subGoalSnapshot.validTo.isNull())
-            )
-            .fetchOne();
+                         .select(subGoalSnapshot.count())
+                         .from(subGoalSnapshot)
+                         .join(subGoalSnapshot.subGoal, subGoal)
+                         .join(subGoal.coreGoal, coreGoal)
+                         .where(
+                             coreGoal.id.eq(coreGoalId)
+                                 .and(subGoalSnapshot.validTo.isNull())
+                         )
+                         .fetchOne();
 
         return Math.toIntExact(count != null ? count : 0L);
     }
@@ -137,13 +129,13 @@ public class SubGoalSnapshotRepositoryImpl implements SubGoalSnapshotRepositoryC
     @Override
     public List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId) {
         return queryFactory
-            .select(subGoal.position)
-            .from(subGoalSnapshot)
-            .join(subGoalSnapshot.subGoal, subGoal)
-            .join(subGoal.coreGoal, coreGoal)
-            .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
-            .where(coreGoal.id.eq(coreGoalId)
-                .and(subGoalSnapshot.validTo.isNull()))
-            .fetch();
+                   .select(subGoal.position)
+                   .from(subGoalSnapshot)
+                   .join(subGoalSnapshot.subGoal, subGoal)
+                   .join(subGoal.coreGoal, coreGoal)
+                   .join(coreGoalSnapshot).on(coreGoalSnapshot.coreGoal.eq(coreGoal))
+                   .where(coreGoal.id.eq(coreGoalId)
+                              .and(subGoalSnapshot.validTo.isNull()))
+                   .fetch();
     }
 }

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/SubGoalQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/SubGoalQueryService.java
@@ -38,11 +38,12 @@ public class SubGoalQueryService {
         coreGoalSnapshot.verifyCoreGoalUser(userId);
 
         List<SubGoalSnapshot> subGoals = subGoalSnapshotRepository
-            .findByCoreGoalSnapshotIdOrderByPosition(coreGoalSnapshotId);
+                                             .findByCoreGoalSnapshotIdOrderByPosition(
+                                                 coreGoalSnapshotId);
 
         return subGoals.stream()
-            .map(SubGoalIdResponse::from)
-            .toList();
+                   .map(SubGoalIdResponse::from)
+                   .toList();
     }
 
     public SubGoalListResponse getSubGoalWithFilter(
@@ -68,13 +69,14 @@ public class SubGoalQueryService {
 
     private CoreGoalSnapshot findCoreGoalOrThrow(Long coreGoalSnapshotId) {
         return coreGoalSnapshotRepository.findById(coreGoalSnapshotId)
-            .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
+                   .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
     }
 
     private SubGoalListResponse filterNothing(Long userId, Long mandalartId) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findAllActiveSubGoalSnapshot(mandalartId).stream()
+            subGoalSnapshotRepository.findAllActiveSubGoalSnapshotOrderByPosition(mandalartId)
+                .stream()
                 .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
     }
@@ -82,7 +84,8 @@ public class SubGoalQueryService {
     private SubGoalListResponse filterByCycle(Long userId, Long mandalartId, Cycle cycle) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotByCycle(mandalartId, cycle)
+            subGoalSnapshotRepository.findActiveSubGoalSnapshotByCycleOrderByPosition(mandalartId,
+                    cycle)
                 .stream()
                 .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
@@ -93,7 +96,8 @@ public class SubGoalQueryService {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCoreGoal(mandalartId,
+            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
+                    mandalartId,
                     coreGoalSnapshotId).stream()
                 .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
@@ -104,7 +108,7 @@ public class SubGoalQueryService {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCycleAndCoreGoal(
+            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
                     mandalartId, coreGoalSnapshotId, cycle).stream()
                 .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
@@ -112,7 +116,7 @@ public class SubGoalQueryService {
 
     private void verifyMandalartByUser(Long userId, Long mandalartId) {
         Mandalart mandalart = mandalartRepository.findById(mandalartId)
-            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+                                  .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
         mandalart.ensureOwnedBy(userId);
     }
 

--- a/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/SubGoalQueryService.java
+++ b/src/main/java/org/sopt36/ninedotserver/mandalart/service/query/SubGoalQueryService.java
@@ -3,6 +3,7 @@ package org.sopt36.ninedotserver.mandalart.service.query;
 import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
 import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.mandalart.domain.CoreGoalSnapshot;
@@ -16,6 +17,7 @@ import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.CoreGoalSnapshotRepository;
+import org.sopt36.ninedotserver.mandalart.repository.HistoryRepository;
 import org.sopt36.ninedotserver.mandalart.repository.MandalartRepository;
 import org.sopt36.ninedotserver.mandalart.repository.SubGoalRepository;
 import org.sopt36.ninedotserver.mandalart.repository.SubGoalSnapshotRepository;
@@ -32,91 +34,115 @@ public class SubGoalQueryService {
     private final MandalartRepository mandalartRepository;
     private final CoreGoalSnapshotRepository coreGoalSnapshotRepository;
     private final SubGoalSnapshotRepository subGoalSnapshotRepository;
+    private final HistoryRepository historyRepository;
 
     public List<SubGoalIdResponse> getSubGoalIds(Long userId, Long coreGoalSnapshotId) {
         CoreGoalSnapshot coreGoalSnapshot = findCoreGoalOrThrow(coreGoalSnapshotId);
         coreGoalSnapshot.verifyCoreGoalUser(userId);
 
         List<SubGoalSnapshot> subGoals = subGoalSnapshotRepository
-                                             .findByCoreGoalSnapshotIdOrderByPosition(
-                                                 coreGoalSnapshotId);
+            .findByCoreGoalSnapshotIdOrderByPosition(
+                coreGoalSnapshotId);
 
         return subGoals.stream()
-                   .map(SubGoalIdResponse::from)
-                   .toList();
+            .map(SubGoalIdResponse::from)
+            .toList();
     }
 
     public SubGoalListResponse getSubGoalWithFilter(
         Long userId,
         Long mandalartId,
         Long coreGoalSnapshotId,
-        Cycle cycle
+        Cycle cycle,
+        LocalDate date
     ) {
         if (coreGoalSnapshotId == null && cycle == null) {
-            return filterNothing(userId, mandalartId);
+            return filterNothing(userId, mandalartId, date);
         }
 
         if (coreGoalSnapshotId == null) {
-            return filterByCycle(userId, mandalartId, cycle);
+            return filterByCycle(userId, mandalartId, cycle, date);
         }
 
         if (cycle == null) {
-            return filterByCoreGoalSnapshot(userId, mandalartId, coreGoalSnapshotId);
+            return filterByCoreGoalSnapshot(userId, mandalartId, coreGoalSnapshotId, date);
         }
 
-        return filterByCoreGoalSnapshotAndCycle(userId, mandalartId, coreGoalSnapshotId, cycle);
+        return filterByCoreGoalSnapshotAndCycle(userId, mandalartId, coreGoalSnapshotId, cycle,
+            date);
     }
 
     private CoreGoalSnapshot findCoreGoalOrThrow(Long coreGoalSnapshotId) {
         return coreGoalSnapshotRepository.findById(coreGoalSnapshotId)
-                   .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
+            .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
     }
 
-    private SubGoalListResponse filterNothing(Long userId, Long mandalartId) {
+    private SubGoalListResponse filterNothing(Long userId, Long mandalartId, LocalDate date) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findAllActiveSubGoalSnapshotOrderByPosition(mandalartId)
+            subGoalSnapshotRepository.findAllActiveSubGoalSnapshotOrderByPosition(mandalartId, date)
                 .stream()
-                .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
+                .map(subGoalSnapshot -> {
+                        boolean isCompleted = historyRepository
+                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                    }
+                ).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
     }
 
-    private SubGoalListResponse filterByCycle(Long userId, Long mandalartId, Cycle cycle) {
+    private SubGoalListResponse filterByCycle(Long userId, Long mandalartId, Cycle cycle,
+        LocalDate date) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
             subGoalSnapshotRepository.findActiveSubGoalSnapshotByCycleOrderByPosition(mandalartId,
                     cycle)
                 .stream()
-                .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
+                .map(subGoalSnapshot -> {
+                        boolean isCompleted = historyRepository
+                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                    }
+                ).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
     }
 
     private SubGoalListResponse filterByCoreGoalSnapshot(Long userId, Long mandalartId,
-        Long coreGoalSnapshotId) {
+        Long coreGoalSnapshotId, LocalDate date) {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
             subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
                     mandalartId,
                     coreGoalSnapshotId).stream()
-                .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
+                .map(subGoalSnapshot -> {
+                        boolean isCompleted = historyRepository
+                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                    }
+                ).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
     }
 
     private SubGoalListResponse filterByCoreGoalSnapshotAndCycle(Long userId, Long mandalartId,
-        Long coreGoalSnapshotId, Cycle cycle) {
+        Long coreGoalSnapshotId, Cycle cycle, LocalDate date) {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
             subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
                     mandalartId, coreGoalSnapshotId, cycle).stream()
-                .map(SubGoalDetailResponse::from).filter(subGoal -> !subGoal.title().isEmpty())
+                .map(subGoalSnapshot -> {
+                        boolean isCompleted = historyRepository
+                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                    }
+                ).filter(subGoal -> !subGoal.title().isEmpty())
                 .toList());
     }
 
     private void verifyMandalartByUser(Long userId, Long mandalartId) {
         Mandalart mandalart = mandalartRepository.findById(mandalartId)
-                                  .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
         mandalart.ensureOwnedBy(userId);
     }
 


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #136

### ⭐️ 구현 내용
- [x] sub goal position 순서대로 반환
- [ ] 날짜별로 반환
- [ ] 완료여부도 반환

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 하위 목표 스냅샷 조회 시 결과가 위치 기준으로 정렬되도록 메서드 명과 내부 호출을 일관성 있게 변경하였습니다.
  * 일부 코드의 들여쓰기 및 포매팅이 개선되었습니다.
* **New Features**
  * 하위 목표 조회 시 선택한 날짜에 따른 완료 여부를 함께 확인하여 응답에 포함하도록 기능을 확장하였습니다.
  * 추천 목표 조회 시에도 날짜별 완료 상태를 반영하여 사용자에게 보다 정확한 정보를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->