### PR TITLE
[HOTFIX] #178: 실행 환경, 애플리케이션 환경 버전 불일치 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
 FROM gradle:8.7.0-jdk17-alpine AS build
 WORKDIR /app
-COPY . .
 ARG BOOT_MODULE=ninedot-api
-RUN chmod +x ./gradlew && ./gradlew :${BOOT_MODULE}:bootJar -x test
-RUN mkdir -p /out && \
-    cp ${BOOT_MODULE}/build/libs/*-SNAPSHOT.jar /out/app.jar || \
-    cp ${BOOT_MODULE}/build/libs/*.jar /out/app.jar
+
+COPY gradlew gradlew.bat ./
+COPY gradle ./gradle
+COPY settings.gradle* build.gradle* ./
+COPY ${BOOT_MODULE}/build.gradle* ${BOOT_MODULE}/
+
+RUN chmod +x ./gradlew
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    ./gradlew --no-daemon :${BOOT_MODULE}:dependencies -x test || true
+
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    ./gradlew --no-daemon :${BOOT_MODULE}:bootJar -x test
+
+RUN set -e; mkdir -p /out; \
+    JAR="$(ls -1 ${BOOT_MODULE}/build/libs/*.jar 2>/dev/null | grep -v -- '-plain\.jar' | head -n1)"; \
+    if [ -z "$JAR" ]; then echo "Boot JAR not found"; exit 1; fi; \
+    cp "$JAR" /out/app.jar
 
 FROM eclipse-temurin:17.0.12_7-jre-alpine
 
@@ -22,5 +36,4 @@ RUN mkdir -p /tmp /app/logs && chown -R app:app /app /tmp
 COPY --from=build --chown=app:app /out/app.jar /app/app.jar
 
 USER app
-
 ENTRYPOINT ["java","-Duser.timezone=Asia/Seoul","-Djava.io.tmpdir=/tmp","-jar","/app/app.jar"]


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #178

### ⭐️ 구현 내용
- [ ] 실행 환경과 애플리케이션 환경이 달라서 서버 무한 재시작하는 문제 수정
---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - 빌드·런타임 베이스 이미지를 Alpine 기반으로 전환해 이미지 크기·보안 개선.
  - 빌드 단계 캐시 유지 및 의존성/빌드 단계를 분리해 빌드 효율 향상.
  - 패키지 관리자 apt→apk 전환, tzdata·인증서 설치로 시간대 및 인증서 처리 개선(ENV TZ 제거).
  - 비루트 사용자(app)로 컨테이너 실행 및 애플리케이션 파일 소유권 설정으로 보안 강화.
  - JAVA_TOOL_OPTIONS 기본 옵션 추가 및 임시디렉터리 경로 명시로 런타임 안정성 향상.
  - 애플리케이션 JAR 위치·작업디렉터리 및 ENTRYPOINT 경로 명시화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->