### PR TITLE
[HOTFIX] #180: 로그인 api 응답에 회원 존재 여부 필드 추가

### DIFF
--- a/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/dto/response/AuthLoginResponse.java
+++ b/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/dto/response/AuthLoginResponse.java
@@ -3,6 +3,7 @@ package org.sopt36.ninedotserver.auth.adapter.in.web.v1.dto.response;
 import org.sopt36.ninedotserver.auth.model.OnboardingPage;
 
 public record AuthLoginResponse(
+    boolean exists,
     Long userId,
     String accessToken,
     boolean onboardingCompleted,

--- a/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/dto/response/AuthSignupResponse.java
+++ b/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/dto/response/AuthSignupResponse.java
@@ -1,9 +1,9 @@
 package org.sopt36.ninedotserver.auth.adapter.in.web.v1.dto.response;
 
 public record AuthSignupResponse(
+    boolean exists,
     String socialProvider,
     String socialToken,
-    boolean exists,
     String name,
     String email,
     String profileImageUrl

--- a/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/mapper/AuthResponseMapper.java
+++ b/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/mapper/AuthResponseMapper.java
@@ -15,6 +15,7 @@ public class AuthResponseMapper {
     public static AuthResponse toResponse(AuthResult authResult) {
         if (authResult instanceof LoginResult loginResult) {
             return new AuthLoginResponse(
+                true,
                 loginResult.userId(),
                 loginResult.accessToken(),
                 loginResult.onboardingCompleted(),
@@ -23,9 +24,9 @@ public class AuthResponseMapper {
         }
         if (authResult instanceof SignupResult signupResult) {
             return new AuthSignupResponse(
+                false,
                 signupResult.provider().toString(),
                 signupResult.providerToken(),
-                false,
                 signupResult.name(),
                 signupResult.email(),
                 signupResult.picture()


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #180

### ⭐️ 구현 내용
로그인 응답에 회원 존재 여부 필드 필요 없을 줄 알고 뺐다가 프론트 쪽에서 구분이 안 돼서 다시 추가합니다
---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인·회원가입 응답에 ‘계정 존재 여부’가 포함되어, 앱이 첫 방문자와 기존 사용자를 즉시 구분합니다.
  - 이에 따라 온보딩 진행 여부와 다음 화면 전환이 더 정확해지고, 불필요한 단계가 줄어 더욱 빠르게 서비스를 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->