### PR TITLE
[HOTFIX] #183: 구글 로그인 시 회원 없는 경우 응답 수정

### DIFF
--- a/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/mapper/AuthResponseMapper.java
+++ b/ninedot-api/src/main/java/org/sopt36/ninedotserver/auth/adapter/in/web/v1/mapper/AuthResponseMapper.java
@@ -26,7 +26,7 @@ public class AuthResponseMapper {
             return new AuthSignupResponse(
                 false,
                 signupResult.provider().toString(),
-                signupResult.providerToken(),
+                signupResult.providerUserId(),
                 signupResult.name(),
                 signupResult.email(),
                 signupResult.picture()

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/dto/result/SignupResult.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/dto/result/SignupResult.java
@@ -6,7 +6,7 @@ import org.sopt36.ninedotserver.auth.support.CookieInstruction;
 
 public record SignupResult(
     ProviderType provider,
-    String providerToken,
+    String providerUserId,
     String name,
     String email,
     String picture,

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/service/login/AuthAccountService.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/service/login/AuthAccountService.java
@@ -55,7 +55,7 @@ public class AuthAccountService {
 
         return new SignupResult(
             ProviderType.GOOGLE,
-            exchangeResult.providerAccessToken(),
+            exchangeResult.identityUserInfo().sub(),
             exchangeResult.identityUserInfo().name(),
             exchangeResult.identityUserInfo().email(),
             exchangeResult.identityUserInfo().pictureUrl(),


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #183

### ⭐️ 구현 내용
헥사고날로 옮기는 과정에서 api 응답 필드에 token 있는 것만 보고 실수로 google에 접근하는 access token을 반환해버리는 바보 같은 실수를 수정했습니다 😰😰

추후 변수명이 또 헷갈릴 거 같아서 바꿀 필요가 있을 것 같네요...!!

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음
- 버그 수정
  - 회원가입 처리 시 외부 계정 식별값 매핑을 바로잡아 일부 사용자에서 발생하던 회원가입/로그인 실패를 해소했습니다.
  - 인증 응답 내 표시 정보의 일관성을 개선했습니다.
- 리팩터링
  - 인증 결과 데이터 구조를 정돈하고 명확성을 높여 향후 유지보수를 용이하게 했습니다.
  - 내부 로직 간 의존성을 정리해 흐름을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->