### PR TITLE
[HOTFIX] #191: 하위목표 전체 조회(주기 포함 o) 시 과거 데이터 존재 여부(isYesterdayExist) 반환 추가

### DIFF
--- a/ninedot-api/src/main/java/org/sopt36/ninedotserver/mandalart/v1/RecommendationController.java
+++ b/ninedot-api/src/main/java/org/sopt36/ninedotserver/mandalart/v1/RecommendationController.java
@@ -6,6 +6,7 @@ import static org.sopt36.ninedotserver.mandalart.v1.message.RecommendationMessag
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.sopt36.ninedotserver.dto.response.ApiResponse;
+import org.sopt36.ninedotserver.mandalart.dto.response.RecommendationListResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
 import org.sopt36.ninedotserver.mandalart.usecase.command.RecommendationSchedulerService;
 import org.sopt36.ninedotserver.mandalart.usecase.query.RecommendationQueryService;
@@ -28,7 +29,7 @@ public class RecommendationController {
     private final RecommendationSchedulerService schedulerService;
 
     @GetMapping("/mandalarts/{mandalartId}/histories/recommendation")
-    public ResponseEntity<ApiResponse<SubGoalListResponse, Void>> getRecommendations(
+    public ResponseEntity<ApiResponse<RecommendationListResponse, Void>> getRecommendations(
         Authentication authentication,
         @PathVariable Long mandalartId,
         @RequestParam(value = "date", required = false)
@@ -37,7 +38,7 @@ public class RecommendationController {
         Long userId = Long.parseLong(authentication.getName());
         LocalDate recommendationDate = (date != null ? date : LocalDate.now());
 
-        SubGoalListResponse response = recommendationQueryService.getRecommendations(
+        RecommendationListResponse response = recommendationQueryService.getRecommendations(
             userId,
             mandalartId,
             recommendationDate

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/RecommendationListResponse.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/RecommendationListResponse.java
@@ -1,0 +1,11 @@
+package org.sopt36.ninedotserver.mandalart.dto.response;
+
+import java.util.List;
+
+public record RecommendationListResponse(
+        List<SubGoalDetailResponse> subGoals
+) {
+    public static RecommendationListResponse of(List<SubGoalDetailResponse> subGoals) {
+        return new RecommendationListResponse(List.copyOf(subGoals));
+    }
+}

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalListResponse.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/dto/response/SubGoalListResponse.java
@@ -3,10 +3,11 @@ package org.sopt36.ninedotserver.mandalart.dto.response;
 import java.util.List;
 
 public record SubGoalListResponse(
-    List<SubGoalDetailResponse> subGoals
+        boolean isYesterdayExist,
+        List<SubGoalDetailResponse> subGoals
 ) {
 
-    public static SubGoalListResponse of(List<SubGoalDetailResponse> subGoalDetailResponseList) {
-        return new SubGoalListResponse(List.copyOf(subGoalDetailResponseList));
+    public static SubGoalListResponse of(boolean isYesterdayExist, List<SubGoalDetailResponse> subGoalDetailResponseList) {
+        return new SubGoalListResponse(isYesterdayExist, List.copyOf(subGoalDetailResponseList));
     }
 }

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/usecase/query/RecommendationQueryService.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/usecase/query/RecommendationQueryService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt36.ninedotserver.mandalart.dto.response.RecommendationListResponse;
 import org.sopt36.ninedotserver.mandalart.model.Mandalart;
 import org.sopt36.ninedotserver.mandalart.model.Recommendation;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalDetailResponse;
@@ -26,7 +27,7 @@ public class RecommendationQueryService {
     private final MandalartRepositoryPort mandalartRepository;
     private final HistoryRepositoryPort historyRepository;
 
-    public SubGoalListResponse getRecommendations(Long userId, Long mandalartId, LocalDate date) {
+    public RecommendationListResponse getRecommendations(Long userId, Long mandalartId, LocalDate date) {
         Mandalart mandalart = getExistingMandalart(mandalartId);
         mandalart.ensureOwnedBy(userId);
 
@@ -46,7 +47,7 @@ public class RecommendationQueryService {
             })
             .collect(Collectors.toList());
 
-        return SubGoalListResponse.of(subGoals);
+        return RecommendationListResponse.of(subGoals);
     }
 
     private Mandalart getExistingMandalart(Long mandalartId) {

--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/usecase/query/SubGoalQueryService.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/mandalart/usecase/query/SubGoalQueryService.java
@@ -1,26 +1,28 @@
 package org.sopt36.ninedotserver.mandalart.usecase.query;
 
-import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
-import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
-
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt36.ninedotserver.mandalart.model.CoreGoalSnapshot;
-import org.sopt36.ninedotserver.mandalart.model.Cycle;
-import org.sopt36.ninedotserver.mandalart.model.Mandalart;
-import org.sopt36.ninedotserver.mandalart.model.SubGoalSnapshot;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalDetailResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalIdResponse;
 import org.sopt36.ninedotserver.mandalart.dto.response.SubGoalListResponse;
 import org.sopt36.ninedotserver.mandalart.exception.MandalartException;
 import org.sopt36.ninedotserver.mandalart.exception.SubGoalException;
+import org.sopt36.ninedotserver.mandalart.model.CoreGoalSnapshot;
+import org.sopt36.ninedotserver.mandalart.model.Cycle;
+import org.sopt36.ninedotserver.mandalart.model.Mandalart;
+import org.sopt36.ninedotserver.mandalart.model.SubGoalSnapshot;
 import org.sopt36.ninedotserver.mandalart.port.out.CoreGoalSnapshotRepositoryPort;
 import org.sopt36.ninedotserver.mandalart.port.out.HistoryRepositoryPort;
 import org.sopt36.ninedotserver.mandalart.port.out.MandalartRepositoryPort;
 import org.sopt36.ninedotserver.mandalart.port.out.SubGoalSnapshotRepositoryPort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.sopt36.ninedotserver.mandalart.exception.MandalartErrorCode.MANDALART_NOT_FOUND;
+import static org.sopt36.ninedotserver.mandalart.exception.SubGoalErrorCode.CORE_GOAL_NOT_FOUND;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -37,107 +39,123 @@ public class SubGoalQueryService {
         coreGoalSnapshot.verifyCoreGoalUser(userId);
 
         List<SubGoalSnapshot> subGoals = subGoalSnapshotRepository
-            .findByCoreGoalSnapshotIdOrderByPosition(coreGoalSnapshotId);
+                .findByCoreGoalSnapshotIdOrderByPosition(coreGoalSnapshotId);
 
         return subGoals.stream()
-            .map(SubGoalIdResponse::from)
-            .toList();
+                .map(SubGoalIdResponse::from)
+                .toList();
     }
 
     public SubGoalListResponse getSubGoalWithFilter(
-        Long userId,
-        Long mandalartId,
-        Long coreGoalSnapshotId,
-        Cycle cycle,
-        LocalDate date
+            Long userId,
+            Long mandalartId,
+            Long coreGoalSnapshotId,
+            Cycle cycle,
+            LocalDate date
     ) {
+
+        boolean isYesterdayExist = hasYesterdayData(mandalartId, date.minusDays(1));
+
         if (coreGoalSnapshotId == null && cycle == null) {
-            return filterNothing(userId, mandalartId, date);
+            return filterNothing(userId, mandalartId, date, isYesterdayExist);
         }
 
         if (coreGoalSnapshotId == null) {
-            return filterByCycle(userId, mandalartId, cycle, date);
+            return filterByCycle(userId, mandalartId, cycle, date, isYesterdayExist);
         }
 
         if (cycle == null) {
-            return filterByCoreGoalSnapshot(userId, mandalartId, coreGoalSnapshotId, date);
+            return filterByCoreGoalSnapshot(userId, mandalartId, coreGoalSnapshotId, date, isYesterdayExist);
         }
 
         return filterByCoreGoalSnapshotAndCycle(userId, mandalartId, coreGoalSnapshotId, cycle,
-            date);
+                date, isYesterdayExist);
+    }
+
+    private boolean hasYesterdayData(Long mandalartId, LocalDate yesterday) {
+        LocalDateTime endOfDay = yesterday.atTime(23, 59, 59);
+        return subGoalSnapshotRepository.existsBySubGoal_CoreGoal_Mandalart_IdAndValidFromLessThanEqual(mandalartId, endOfDay);
     }
 
     private CoreGoalSnapshot findCoreGoalOrThrow(Long coreGoalSnapshotId) {
         return coreGoalSnapshotRepository.findById(coreGoalSnapshotId)
-            .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
+                .orElseThrow(() -> new SubGoalException(CORE_GOAL_NOT_FOUND));
     }
 
-    private SubGoalListResponse filterNothing(Long userId, Long mandalartId, LocalDate date) {
+    private SubGoalListResponse filterNothing(Long userId, Long mandalartId, LocalDate date, boolean isYesterdayExist) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findAllActiveSubGoalSnapshotOrderByPosition(mandalartId, date)
-                .stream()
-                .map(subGoalSnapshot -> {
-                        boolean isCompleted = historyRepository
-                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
-                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
-                    }
-                ).filter(subGoal -> !subGoal.title().isEmpty())
-                .toList());
+                isYesterdayExist,
+                subGoalSnapshotRepository.findAllActiveSubGoalSnapshotOrderByPosition(mandalartId, date)
+                        .stream()
+                        .map(subGoalSnapshot -> {
+                                    boolean isCompleted = historyRepository
+                                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                                    return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                                }
+                        ).filter(subGoal -> !subGoal.title().isEmpty())
+                        .toList()
+        );
     }
 
     private SubGoalListResponse filterByCycle(Long userId, Long mandalartId, Cycle cycle,
-        LocalDate date) {
+                                              LocalDate date, boolean isYesterdayExist) {
         verifyMandalartByUser(userId, mandalartId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotByCycleOrderByPosition(mandalartId,
-                    cycle)
-                .stream()
-                .map(subGoalSnapshot -> {
-                        boolean isCompleted = historyRepository
-                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
-                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
-                    }
-                ).filter(subGoal -> !subGoal.title().isEmpty())
-                .toList());
+                isYesterdayExist,
+                subGoalSnapshotRepository.findActiveSubGoalSnapshotByCycleOrderByPosition(mandalartId,
+                                cycle)
+                        .stream()
+                        .map(subGoalSnapshot -> {
+                                    boolean isCompleted = historyRepository
+                                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                                    return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                                }
+                        ).filter(subGoal -> !subGoal.title().isEmpty())
+                        .toList()
+        );
     }
 
     private SubGoalListResponse filterByCoreGoalSnapshot(Long userId, Long mandalartId,
-        Long coreGoalSnapshotId, LocalDate date) {
+                                                         Long coreGoalSnapshotId, LocalDate date, boolean isYesterdayExist) {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
-                    mandalartId,
-                    coreGoalSnapshotId).stream()
-                .map(subGoalSnapshot -> {
-                        boolean isCompleted = historyRepository
-                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
-                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
-                    }
-                ).filter(subGoal -> !subGoal.title().isEmpty())
-                .toList());
+                isYesterdayExist,
+                subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
+                                mandalartId,
+                                coreGoalSnapshotId).stream()
+                        .map(subGoalSnapshot -> {
+                                    boolean isCompleted = historyRepository
+                                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                                    return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                                }
+                        ).filter(subGoal -> !subGoal.title().isEmpty())
+                        .toList()
+        );
     }
 
     private SubGoalListResponse filterByCoreGoalSnapshotAndCycle(Long userId, Long mandalartId,
-        Long coreGoalSnapshotId, Cycle cycle, LocalDate date) {
+                                                                 Long coreGoalSnapshotId, Cycle cycle, LocalDate date, boolean isYesterdayExist) {
         verifyMandalartByUser(userId, mandalartId);
         verifyCoreGoalByUser(userId, coreGoalSnapshotId);
         return SubGoalListResponse.of(
-            subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
-                    mandalartId, coreGoalSnapshotId, cycle).stream()
-                .map(subGoalSnapshot -> {
-                        boolean isCompleted = historyRepository
-                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
-                        return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
-                    }
-                ).filter(subGoal -> !subGoal.title().isEmpty())
-                .toList());
+                isYesterdayExist,
+                subGoalSnapshotRepository.findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
+                                mandalartId, coreGoalSnapshotId, cycle).stream()
+                        .map(subGoalSnapshot -> {
+                                    boolean isCompleted = historyRepository
+                                            .existsBySubGoalSnapshotIdAndCompletedDate(subGoalSnapshot.getId(), date);
+                                    return SubGoalDetailResponse.of(subGoalSnapshot, isCompleted);
+                                }
+                        ).filter(subGoal -> !subGoal.title().isEmpty())
+                        .toList()
+        );
     }
 
     private void verifyMandalartByUser(Long userId, Long mandalartId) {
         Mandalart mandalart = mandalartRepository.findById(mandalartId)
-            .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
+                .orElseThrow(() -> new MandalartException(MANDALART_NOT_FOUND));
         mandalart.ensureOwnedBy(userId);
     }
 

--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/mandalart/port/out/SubGoalSnapshotRepositoryPort.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/mandalart/port/out/SubGoalSnapshotRepositoryPort.java
@@ -1,6 +1,7 @@
 package org.sopt36.ninedotserver.mandalart.port.out;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.sopt36.ninedotserver.mandalart.model.CoreGoal;
@@ -41,4 +42,6 @@ public interface SubGoalSnapshotRepositoryPort {
     int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId);
 
     List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId);
+
+    boolean existsBySubGoal_CoreGoal_Mandalart_IdAndValidFromLessThanEqual(Long mandalartId, LocalDateTime targetDate);
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #

### ⭐️ 구현 내용
- [ ] SubGoalQueryService -> SubGoalListResponse 반환 시 isYesterdayExist 포함하도록 리팩토링
- [ ] RecommendationController & QueryService -> RecommendationlistResponse 반환하도록 변경 (isYesterdayExist 필드가 없는 dto 생성)

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
