### PR TITLE
[HOTFIX] #193: 어제로 이동 가능 여부를 온보딩 완료일 기반으로 수정

### DIFF
--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/mandalart/port/out/SubGoalSnapshotRepositoryPort.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/mandalart/port/out/SubGoalSnapshotRepositoryPort.java
@@ -1,12 +1,12 @@
 package org.sopt36.ninedotserver.mandalart.port.out;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.sopt36.ninedotserver.mandalart.model.CoreGoal;
 import org.sopt36.ninedotserver.mandalart.model.Cycle;
 import org.sopt36.ninedotserver.mandalart.model.SubGoalSnapshot;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 public interface SubGoalSnapshotRepositoryPort {
 
@@ -23,25 +23,24 @@ public interface SubGoalSnapshotRepositoryPort {
     List<SubGoalSnapshot> findAllByMandalartId(Long mandalartId);
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCoreGoalOrderByPosition(
-        Long mandalartId, Long id);
+            Long mandalartId, Long id);
 
     void delete(SubGoalSnapshot subGoalSnapshot);
 
     List<SubGoalSnapshot> findByCoreGoalSnapshotIdOrderByPosition(Long coreGoalSnapshotId);
 
     List<SubGoalSnapshot> findAllActiveSubGoalSnapshotOrderByPosition(Long mandalartId,
-        LocalDate date);
+                                                                      LocalDate date);
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotByCycleOrderByPosition(Long mandalartId,
-        Cycle cycle);
+                                                                          Cycle cycle);
 
     List<SubGoalSnapshot> findActiveSubGoalSnapshotFollowingCycleAndCoreGoalOrderByPosition(
-        Long mandalartId, Long coreGoalSnapshotId,
-        Cycle cycle);
+            Long mandalartId, Long coreGoalSnapshotId,
+            Cycle cycle);
 
     int countActiveSubGoalSnapshotByCoreGoal(Long coreGoalId);
 
     List<Integer> findActiveSubGoalPositionsByCoreGoal(Long coreGoalId);
 
-    boolean existsBySubGoal_CoreGoal_Mandalart_IdAndValidFromLessThanEqual(Long mandalartId, LocalDateTime targetDate);
 }

--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/User.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/User.java
@@ -14,6 +14,8 @@ import org.sopt36.ninedotserver.user.model.value.Email;
 import org.sopt36.ninedotserver.user.model.value.ProfileImageUrl;
 import org.sopt36.ninedotserver.user.model.value.UserName;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -54,6 +56,9 @@ public class User extends BaseEntity {
     @Column(name = "onboarding_completed", nullable = false)
     @ColumnDefault(value = "false")
     private Boolean onboardingCompleted;
+
+    @Column(name = "onboarding_completed_at")
+    private LocalDate onboardingCompletedAt;
 
     public static User create(
         String name,
@@ -105,6 +110,7 @@ public class User extends BaseEntity {
     public void completeOnboarding() {
         if (Boolean.FALSE.equals(this.onboardingCompleted)) {
             this.onboardingCompleted = true;
+            this.onboardingCompletedAt = LocalDate.now();
         }
     }
 


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #193

### ⭐️ 구현 내용
- [x] 기존: SubGoalSnapshot 유무로 어제 데이터 존재 여부를 판단 -> 이는 온보딩 이후에도 어제 데이터가 없을 수 있다(하위 목표 삭제 등으로 과거 데이터가 없을 수도 있다.)
- [x] 변경: User.onboardingCompletedAt을 기준으로 어제로 이동 가능 여부 판단

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
