### PR TITLE
[HOTFIX] #201: 회원가입 시 트랜잭션 충돌 해결

### DIFF
--- a/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/service/signup/SignupHandler.java
+++ b/ninedot-application/src/main/java/org/sopt36/ninedotserver/auth/service/signup/SignupHandler.java
@@ -42,7 +42,7 @@ public class SignupHandler implements SignupUsecase {
             signupCommand.birthday(),
             signupCommand.job()
         );
-        userCommandPort.save(user);
+        userCommandPort.saveAndFlush(user);
 
         List<Answer> answers = getAnswers(signupCommand, user);
         answerRepositoryPort.saveAll(answers);

--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/JobType.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/JobType.java
@@ -35,8 +35,8 @@ public enum JobType {
     public static JobType from(String raw) {
         validateNotBlank(raw);
         return findByName(raw)
-                .or(() -> findByDisplayName(raw))
-                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_JOB_VALUE));
+            .or(() -> findByDisplayName(raw.trim()))
+            .orElseThrow(() -> new UserException(UserErrorCode.INVALID_JOB_VALUE));
     }
 
     private static void validateNotBlank(String raw) {
@@ -47,14 +47,14 @@ public enum JobType {
 
     private static Optional<JobType> findByName(String raw) {
         return Arrays.stream(JobType.values())
-                .filter(type -> type.name().equalsIgnoreCase(raw))
-                .findFirst();
+            .filter(type -> type.name().equalsIgnoreCase(raw))
+            .findFirst();
     }
 
     private static Optional<JobType> findByDisplayName(String raw) {
         return Arrays.stream(JobType.values())
-                .filter(type -> type.displayName.equalsIgnoreCase(raw))
-                .findFirst();
+            .filter(type -> type.displayName.equalsIgnoreCase(raw))
+            .findFirst();
     }
 
 }

--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/port/out/UserCommandPort.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/port/out/UserCommandPort.java
@@ -4,5 +4,5 @@ import org.sopt36.ninedotserver.user.model.User;
 
 public interface UserCommandPort {
 
-    <S extends User> S save(S user);
+    <S extends User> S saveAndFlush(S user);
 }

--- a/ninedot-infrastructure/src/main/java/org/sopt36/ninedotserver/auth/adapter/out/persistence/jpa/RefreshTokenAdapter.java
+++ b/ninedot-infrastructure/src/main/java/org/sopt36/ninedotserver/auth/adapter/out/persistence/jpa/RefreshTokenAdapter.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
-@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Transactional
 public class RefreshTokenAdapter implements RefreshTokenPort {
 
     private final RefreshTokenRepository refreshTokenJpaRepository;

--- a/ninedot-infrastructure/src/main/java/org/sopt36/ninedotserver/user/persistence/UserPersistenceAdapter.java
+++ b/ninedot-infrastructure/src/main/java/org/sopt36/ninedotserver/user/persistence/UserPersistenceAdapter.java
@@ -23,8 +23,8 @@ public class UserPersistenceAdapter implements UserQueryPort, UserCommandPort {
     }
 
     @Override
-    public <S extends User> S save(S user) {
-        return userRepository.save(user);
+    public <S extends User> S saveAndFlush(S user) {
+        return userRepository.saveAndFlush(user);
     }
 
     @Override


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [ ] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [ ] 리뷰어를 지정해 주세요.
- [ ] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] Assignee 지정해 주세요.
- [ ] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #201

### ⭐️ 구현 내용
- [ ] 회원가입 시 JobType 양옆에 공백 제거하여 직업 값을 정확히 읽도록 변경했습니다.
- [ ] 회원가입 시 유저 저장 후, 토큰 발급할 때 같은 트랜잭션으로 묶여 db에 유저가 바로 저장되지 않는 문제가 있어 refresh token adapter의 토큰 범위를 변경하고, 영속성 컨텍스트에서 유저가 저장되면 바로 flush 할 수 있도록 변경했습니다.

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
