### PR TITLE
[HOTFIX] #206: profile image url 길이 제한 늘림

### DIFF
--- a/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrl.java
+++ b/ninedot-domain/src/main/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrl.java
@@ -5,7 +5,7 @@ import org.sopt36.ninedotserver.user.exception.UserException;
 
 public record ProfileImageUrl(String value) {
 
-    public static final int MAX_LENGTH = 1000;
+    public static final int MAX_LENGTH = 4096;
 
     public ProfileImageUrl {
         validateNotBlank(value);

--- a/ninedot-domain/src/test/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrlTest.java
+++ b/ninedot-domain/src/test/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrlTest.java
@@ -28,21 +28,21 @@ public class ProfileImageUrlTest {
 
         // when & then
         assertThatThrownBy(() -> new ProfileImageUrl(blankUrl))
-                .isInstanceOf(UserException.class)
-                .extracting(e -> ((UserException) e).getErrorCode())
-                .isEqualTo(UserErrorCode.PROFILE_IMAGE_NOT_BLANK);
+            .isInstanceOf(UserException.class)
+            .extracting(e -> ((UserException) e).getErrorCode())
+            .isEqualTo(UserErrorCode.PROFILE_IMAGE_NOT_BLANK);
     }
 
     @Test
     void 너무_긴_URL이면_예외발생() {
         // given
-        String tooLongUrl = "a".repeat(1001);
+        String tooLongUrl = "a".repeat(4097);
 
         // when & then
         assertThatThrownBy(() -> new ProfileImageUrl(tooLongUrl))
-                .isInstanceOf(UserException.class)
-                .extracting(e -> ((UserException) e).getErrorCode())
-                .isEqualTo(UserErrorCode.PROFILE_IMAGE_URL_TOO_LONG);
+            .isInstanceOf(UserException.class)
+            .extracting(e -> ((UserException) e).getErrorCode())
+            .isEqualTo(UserErrorCode.PROFILE_IMAGE_URL_TOO_LONG);
     }
 
 }

--- a/ninedot-domain/src/test/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrlTest.java
+++ b/ninedot-domain/src/test/java/org/sopt36/ninedotserver/user/model/value/ProfileImageUrlTest.java
@@ -36,7 +36,7 @@ public class ProfileImageUrlTest {
     @Test
     void 너무_긴_URL이면_예외발생() {
         // given
-        String tooLongUrl = "a".repeat(4097);
+        String tooLongUrl = "a".repeat(ProfileImageUrl.MAX_LENGTH + 1);
 
         // when & then
         assertThatThrownBy(() -> new ProfileImageUrl(tooLongUrl))


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #206

### ⭐️ 구현 내용
- [x] 현재 프로필 이미지 길이 제한이 1000자로 되어있어 로그인, 회원가입이 안 되는 문제를 수정했습니다.

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 이미지 URL의 최대 허용 길이를 1000자에서 4096자로 확대했습니다.
  * 더 긴 CDN/서드파티 이미지 링크를 문제없이 등록·수정할 수 있어 프로필 설정 유연성이 향상됩니다.
  * 과도한 길이로 인한 유효성 검사 실패 및 오류 메시지 노출이 줄어들어 가입/계정 설정 흐름이 매끄러워집니다.
  * 기존 짧은 URL 사용에는 영향이 없으며 다양한 플랫폼·스토리지 링크 호환성이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->